### PR TITLE
CHECKOUT-3060: Modify template format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## What?
+...
+
+## Why?
+...
+
+## Testing / Proof
+...
+
+ping @bigcommerce/frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
-notifications:
-  email: false
+
 node_js:
   - '10'
   - '9'
   - '8'
   - '7'
   - '6'
+
 before_script:
   - npm prune
+
 script:
+  - npm run validate-commits
   - npm run prepublishOnly
-after_success:
 
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# typedoc-plugin-markdown
+# @bigcommerce/typedoc-plugin-markdown
 
-[![npm](https://img.shields.io/npm/v/typedoc-plugin-markdown.svg)](https://www.npmjs.com/package/typedoc-plugin-markdown)
-[![Build Status](https://travis-ci.org/tgreyjs/typedoc-plugin-markdown.svg?branch=master)](https://travis-ci.org/tgreyjs/typedoc-plugin-markdown)
-[![Greenkeeper badge](https://badges.greenkeeper.io/tgreyjs/typedoc-plugin-markdown.svg)](https://greenkeeper.io/)
-
-A plugin for [TypeDoc](https://github.com/TypeStrong/typedoc) that exposes a theme and additional arguments for rendering markdown.
+A plugin for [TypeDoc](https://github.com/TypeStrong/typedoc) that exposes a
+theme and additional arguments for rendering markdown. This is a forked version
+of [typedoc-plugin-markdown](https://github.com/tgreyjs/typedoc-plugin-markdown)
+that is modified to suit the needs of BigCommerce.
 
 ## Installation
 
 ```javascript
-npm install --save-dev typedoc typedoc-plugin-markdown
+npm install --save-dev typedoc @bigcommerce/typedoc-plugin-markdown
 ```
 
 ## Usage
@@ -37,10 +36,13 @@ $ node_modules/.bin/typedoc --theme markdown
 The plugin exposes the following additional arguments:
 
 * `--mdEngine <github|bitbucket|gitbook>`\
- The markdown rendering engine:\
- **"github":** Optimised for GitHub/CommonMark (Default).\
- **"bitbucket":** Renders markdown to support Bitbucket anchor linking and more.\
- **"gitbook":** Adds SUMMARY.md file to generate a book's table of contents and sets header levels to display correct sub-navigation menu. (*Optimised for newest version of GitBook*).
+  The markdown rendering engine:\
+  **"github":** Optimised for GitHub/CommonMark (Default).\
+  **"bitbucket":** Renders markdown to support Bitbucket anchor linking and
+  more.\
+  **"gitbook":** Adds SUMMARY.md file to generate a book's table of contents and
+  sets header levels to display correct sub-navigation menu. (*Optimised for
+  newest version of GitBook*).
 
 * `--mdHideSources`\
   Suppress source file linking from output.
@@ -51,8 +53,9 @@ The plugin exposes the following additional arguments:
 
 ## Example output
 
-* [Some general example output](https://github.com/tgreyjs/typedoc-plugin-markdown/tree/master/examples/out/README.md).
+* [Some general example output](https://github.com/bigcommerce/typedoc-plugin-markdown/tree/master/examples/out/README.md).
 
 ## Acknowledgements
 
-* Thanks to kimamula's [typedoc-markdown-theme](https://github.com/kimamula/typedoc-markdown-theme) for the inspiration behind this project.
+* Thanks to tgreyjs's original plugin -
+  [typedoc-plugin-markdown](https://github.com/tgreyjs/typedoc-plugin-markdown).

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,0 +1,7 @@
+{
+  "scopes": [
+    "common",
+    "plugin",
+    "theme"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,24 @@
 {
-  "name": "typedoc-plugin-markdown",
+  "name": "@bigcommerce/typedoc-plugin-markdown",
   "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@bigcommerce/validate-commits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/validate-commits/-/validate-commits-2.0.3.tgz",
+      "integrity": "sha512-i0itS+ZgXabmStSh4S+cuGy6Zupcw2BLk2Sfa8s5gVMKizP2CLzTm16nEA9WMWnx9EMh700WxDp+pYm9hwFHjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0"
+      }
+    },
     "@forked/turndown": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@forked/turndown/-/turndown-4.0.4.tgz",
       "integrity": "sha512-GPmVBlNBCdi6GqDTvlRD2lRF3OXd7MBR6smUC5PbkMmh3eKlayGfoxi4CQ5ggnJi9nPZfBZ+85dho6zx6cyf2g==",
       "requires": {
-        "jsdom": "11.10.0"
+        "jsdom": "^11.10.0"
       }
     },
     "@types/chai": {
@@ -30,7 +39,7 @@
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.1"
+        "@types/node": "*"
       }
     },
     "@types/glob": {
@@ -39,9 +48,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.1"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/handlebars": {
@@ -92,8 +101,18 @@
       "integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.35",
-        "@types/node": "9.6.1"
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abab": {
@@ -111,7 +130,7 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "^5.0.0"
       }
     },
     "ajv": {
@@ -119,10 +138,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -131,9 +150,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -160,13 +179,31 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -216,9 +253,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -227,11 +264,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -254,7 +291,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "boom": {
@@ -262,7 +299,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -271,7 +308,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -286,6 +323,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -297,6 +340,17 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -310,8 +364,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -320,12 +374,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-files": {
@@ -334,7 +388,7 @@
       "integrity": "sha1-DiVhD63FUbHq55wvTuefry+EIpY=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2"
+        "assertion-error": "^1.0.1"
       }
     },
     "chalk": {
@@ -343,9 +397,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -354,7 +408,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "has-flag": {
@@ -369,7 +423,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -386,9 +440,9 @@
       "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -403,7 +457,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -425,7 +479,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -439,7 +493,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -448,11 +502,334 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
+    "compare-func": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "dev": true,
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "conventional-changelog": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^1.6.6",
+        "conventional-changelog-atom": "^0.2.8",
+        "conventional-changelog-codemirror": "^0.3.8",
+        "conventional-changelog-core": "^2.0.11",
+        "conventional-changelog-ember": "^0.3.12",
+        "conventional-changelog-eslint": "^1.0.9",
+        "conventional-changelog-express": "^0.3.6",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.3.8",
+        "conventional-changelog-preset-loader": "^1.1.8"
+      }
+    },
+    "conventional-changelog-angular": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-atom": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
+      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-codemirror": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
+      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-core": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
+      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-writer": "^3.0.9",
+        "conventional-commits-parser": "^2.1.7",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.6",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.3.6",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
+      }
+    },
+    "conventional-changelog-ember": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
+      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-eslint": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
+      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-express": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
+      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-jquery": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
+      "dev": true,
+      "requires": {
+        "q": "^1.4.1"
+      }
+    },
+    "conventional-changelog-jscs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
+      "dev": true,
+      "requires": {
+        "q": "^1.4.1"
+      }
+    },
+    "conventional-changelog-jshint": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
+      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-preset-loader": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
+      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
+      "dev": true
+    },
+    "conventional-changelog-writer": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+      "dev": true,
+      "requires": {
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
+      }
+    },
+    "conventional-recommended-bump": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
+      "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        }
+      }
     },
     "copyfiles": {
       "version": "2.0.0",
@@ -460,12 +837,12 @@
       "integrity": "sha512-NSSJdwCH27/hEiBlhkXYWh3AaPo8IATxLX5XtJQgknOvOehrREtETsGd/BNr2vuj0URgKBC/50PNRM3yShQGJQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^0.5.1",
         "noms": "0.0.0",
-        "through2": "2.0.3",
-        "yargs": "11.0.0"
+        "through2": "^2.0.1",
+        "yargs": "^11.0.0"
       }
     },
     "core-util-is": {
@@ -479,9 +856,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -489,7 +866,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -497,7 +874,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -512,7 +889,25 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dargs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -520,7 +915,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -528,10 +923,16 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1"
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
@@ -548,13 +949,31 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.3"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -578,7 +997,26 @@
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "dotgitignore": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
+      "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "minimatch": "^3.0.4"
       }
     },
     "ecc-jsbn": {
@@ -587,7 +1025,16 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -601,11 +1048,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -637,13 +1084,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "extend": {
@@ -671,13 +1118,23 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "forever-agent": {
@@ -690,9 +1147,18 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "requires": {
+        "null-check": "^1.0.0"
       }
     },
     "fs-extra": {
@@ -701,9 +1167,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -724,6 +1190,107 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-pkg-repo": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        }
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -735,7 +1302,57 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "git-raw-commits": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+      "dev": true,
+      "requires": {
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "git-semver-tags": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
+      "dev": true,
+      "requires": {
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.2"
       }
     },
     "glob": {
@@ -744,12 +1361,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -770,10 +1387,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -782,7 +1399,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -797,8 +1414,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -807,7 +1424,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -821,10 +1438,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -844,12 +1461,18 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "http-signature": {
@@ -857,9 +1480,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -867,20 +1490,32 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "interpret": {
@@ -895,16 +1530,52 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-stream": {
@@ -913,10 +1584,31 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true,
+      "requires": {
+        "text-extensions": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -947,8 +1639,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -970,33 +1662,39 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
       "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.5.3",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.9.1",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwmatcher": "1.4.4",
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.2.37 < 0.3.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwmatcher": "^1.4.3",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.85.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.4",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.0",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
       }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1019,8 +1717,14 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1039,7 +1743,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1055,7 +1759,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -1068,8 +1772,20 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -1078,8 +1794,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -1087,10 +1803,35 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -1098,15 +1839,31 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
     "lru-cache": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
     },
     "marked": {
       "version": "0.3.19",
@@ -1120,7 +1877,53 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "meow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        }
       }
     },
     "mime-db": {
@@ -1133,7 +1936,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -1148,7 +1951,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1156,6 +1959,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1193,6 +2006,12 @@
         }
       }
     },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1205,8 +2024,20 @@
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.0.34"
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm-run-path": {
@@ -1215,8 +2046,14 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1234,13 +2071,19 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -1249,8 +2092,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -1266,12 +2109,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-locale": {
@@ -1280,9 +2123,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "p-finally": {
@@ -1297,7 +2140,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -1306,7 +2149,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -1314,6 +2157,22 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
     },
     "parse5": {
       "version": "4.0.0",
@@ -1344,6 +2203,15 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -1354,6 +2222,27 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pn": {
       "version": "1.1.0",
@@ -1388,10 +2277,114 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
     },
     "readable-stream": {
       "version": "1.0.34",
@@ -1399,10 +2392,10 @@
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "rechoir": {
@@ -1411,7 +2404,17 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "repeat-string": {
@@ -1420,33 +2423,42 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise-core": {
@@ -1454,7 +2466,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -1463,8 +2475,8 @@
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -1485,7 +2497,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "right-align": {
@@ -1495,7 +2507,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "safe-buffer": {
@@ -1526,7 +2538,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1541,9 +2553,9 @@
       "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signal-exit": {
@@ -1557,7 +2569,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -1566,6 +2578,56 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "optional": true
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1578,14 +2640,171 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "standard-version": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.4.0.tgz",
+      "integrity": "sha512-jJ8FZhnmh9xJRQLnaXiGRLaAUNItIH29lOQZGpL5fd4+jUHto9Ij6SPCYN86h6ZNNXkYq2TYiIVVF7gVyC+pcQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "conventional-changelog": "^1.1.0",
+        "conventional-recommended-bump": "^1.0.0",
+        "dotgitignore": "^1.0.3",
+        "figures": "^1.5.0",
+        "fs-access": "^1.0.0",
+        "semver": "^5.1.0",
+        "yargs": "^8.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "stealthy-require": {
@@ -1599,8 +2818,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1615,7 +2834,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1637,13 +2856,25 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "supports-color": {
@@ -1652,7 +2883,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "symbol-tree": {
@@ -1660,14 +2891,26 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
+    "text-extensions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -1682,13 +2925,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1697,7 +2940,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1707,7 +2950,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -1722,8 +2965,20 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       }
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
+    },
+    "trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.0",
@@ -1737,18 +2992,18 @@
       "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.1",
-        "commander": "2.15.1",
-        "diff": "3.5.0",
-        "glob": "7.1.2",
-        "js-yaml": "3.11.0",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "semver": "5.5.0",
-        "tslib": "1.9.0",
-        "tsutils": "2.26.2"
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.12.1"
       },
       "dependencies": {
         "commander": {
@@ -1765,7 +3020,7 @@
       "integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "^1.8.1"
       }
     },
     "tunnel-agent": {
@@ -1773,7 +3028,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -1787,13 +3042,19 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typedoc": {
@@ -1809,15 +3070,15 @@
         "@types/marked": "0.3.0",
         "@types/minimatch": "3.0.3",
         "@types/shelljs": "0.7.8",
-        "fs-extra": "5.0.0",
-        "handlebars": "4.0.11",
-        "highlight.js": "9.12.0",
-        "lodash": "4.17.5",
-        "marked": "0.3.19",
-        "minimatch": "3.0.4",
-        "progress": "2.0.0",
-        "shelljs": "0.8.1",
-        "typedoc-default-themes": "0.5.0",
+        "fs-extra": "^5.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.0.0",
+        "lodash": "^4.17.5",
+        "marked": "^0.3.17",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.1",
+        "typedoc-default-themes": "^0.5.0",
         "typescript": "2.7.2"
       }
     },
@@ -1840,9 +3101,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1859,8 +3120,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -1878,9 +3139,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -1910,14 +3171,24 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "w3c-hr-time": {
@@ -1925,7 +3196,7 @@
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "requires": {
-        "browser-process-hrtime": "0.1.2"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "webidl-conversions": {
@@ -1951,9 +3222,9 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
       "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -1962,7 +3233,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -1989,8 +3260,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -1999,7 +3270,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -2008,9 +3279,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -2026,8 +3297,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
       }
     },
     "xml-name-validator": {
@@ -2059,18 +3330,18 @@
       "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "dev": true,
       "requires": {
-        "cliui": "4.0.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       }
     },
     "yargs-parser": {
@@ -2079,7 +3350,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typedoc-plugin-markdown",
+  "name": "@bigcommerce/typedoc-plugin-markdown",
   "version": "1.1.12",
   "description": "A plugin for Typedoc that exposes a theme and additional arguments for rendering markdown.",
   "main": "dist/index.js",
@@ -8,19 +8,25 @@
   ],
   "scripts": {
     "copy:static": "copyfiles --up 1 ./src/**/*.hbs ./dist/",
-    "copy:plugin": "copyfiles package.json './dist/**/*' node_modules/typedoc-plugin-markdown/",
+    "copy:plugin": "copyfiles package.json './dist/**/*' node_modules/@bigcommerce/typedoc-plugin-markdown/",
     "mocks": "npm run mocks:github && npm run mocks:bitbucket && npm run mocks:gitbook",
-    "mocks:github": "typedoc ./test/src --out ./test/out/github --theme markdown --gitRevision master --media test/src/media/ --includes test/src/inc/",
-    "mocks:bitbucket": "typedoc ./test/src --out ./test/out/bitbucket --theme markdown --gitRevision master --media test/src/media/ --includes test/src/inc/ --excludePrivate --readme none --mode file --mdFlavour bitbucket --mdSourceRepo 'https://bitbucket.org/owner/repository_name'",
-    "mocks:gitbook": "typedoc ./test/src --out ./test/out/gitbook --theme markdown --gitRevision master --mdEngine gitbook --media test/src/media/ --includes test/src/inc/",
-    "examples": "rm -rf examples/out && typedoc ./examples/src --out ./examples/out --theme markdown --gitRevision master --readme none --media test/src/media/ --includes test/src/inc/",
+    "mocks:github": "typedoc ./test/src --out ./test/out/github --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --gitRevision master --media test/src/media/ --includes test/src/inc/ --mdSourceRepo 'https://github.com/bigcommerce/typedoc-plugin-markdown'",
+    "mocks:bitbucket": "typedoc ./test/src --out ./test/out/bitbucket --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --gitRevision master --media test/src/media/ --includes test/src/inc/ --excludePrivate --readme none --mode file --mdFlavour bitbucket --mdSourceRepo 'https://bitbucket.org/owner/repository_name'",
+    "mocks:gitbook": "typedoc ./test/src --out ./test/out/gitbook --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --gitRevision master --mdEngine gitbook --media test/src/media/ --includes test/src/inc/ --mdSourceRepo 'https://github.com/bigcommerce/typedoc-plugin-markdown'",
+    "examples": "rm -rf examples/out && typedoc ./examples/src --out ./examples/out --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --gitRevision master --readme none --media test/src/media/ --includes test/src/inc/ --mdSourceRepo 'https://github.com/bigcommerce/typedoc-plugin-markdown'",
     "lint": "tslint --project ./src/tsconfig.json",
     "prepare": "rm -rf dist && tsc -p ./src/tsconfig.json && npm run copy:static",
     "prepublishOnly": "npm run prepare && npm run lint && npm run test",
+    "release": "standard-version",
+    "postrelease": "npm publish --access public && git push --follow-tags",
     "pretest": "rm -rf tests/out && rm -rf node_modules/typedoc-plugin-markdown && npm run copy:plugin && npm run mocks",
-    "test": "mocha test/test.js"
+    "test": "mocha test/test.js",
+    "validate-commits": "validate-commits"
   },
-  "author": "Thomas Grey",
+  "contributors": [
+    "BigCommerce",
+    "Thomas Grey"
+  ],
   "license": "MIT",
   "engines": {
     "node": ">=6"
@@ -42,12 +48,14 @@
     "typedoc": ">=0.9.0"
   },
   "devDependencies": {
+    "@bigcommerce/validate-commits": "^2.0.3",
     "@types/chai": "^4.1.3",
     "@types/mocha": "^5.2.0",
     "chai": "^4.1.2",
     "chai-files": "^1.4.0",
     "copyfiles": "^2.0.0",
     "mocha": "^5.1.1",
+    "standard-version": "^4.2.0",
     "tslint": "^5.10.0",
     "typedoc": "^0.11.1",
     "typescript": "2.7.2"

--- a/src/theme/helpers/getSourceFile.ts
+++ b/src/theme/helpers/getSourceFile.ts
@@ -11,6 +11,8 @@ export function getSourceFile(fileName: string, line: string, url: string) {
     const bitbucketUrl = `${options.mdSourceRepo}/src/master/${fileName}`;
     const bitbucketParams = `fileviewer=file-view-default#${fileName}-${line}`;
     md += `[${fileName}:${line}](${bitbucketUrl}?${bitbucketParams})`;
+  } else if (url && options.mdSourceRepo) {
+    md += `[${fileName}:${line}](${url.replace(/https:\/\/github.com(\/[-\w]+){2}/, options.mdSourceRepo)})`;
   } else if (url) {
     md += `[${fileName}:${line}](${url})`;
   } else {

--- a/src/theme/helpers/ifDisplayIndexItem.ts
+++ b/src/theme/helpers/ifDisplayIndexItem.ts
@@ -1,3 +1,4 @@
+import { ReflectionKind } from 'typedoc/dist/lib/models';
 import { DeclarationReflection } from 'typedoc/dist/lib/models/reflections';
 import { ThemeService } from '../theme.service';
 
@@ -8,7 +9,11 @@ import { ThemeService } from '../theme.service';
  */
 export function ifDisplayIndexItem(item: DeclarationReflection, opts: any) {
   const options = ThemeService.getOptions();
-  if ((item.children && item.children.length === 0) || (options.excludePrivate && item.flags.isPrivate)) {
+  if (
+    (item.children && item.children.length === 0) ||
+    (options.excludePrivate && item.flags.isPrivate) ||
+    (!item.flags.isExported && (item.kind !== ReflectionKind.Method && item.kind !== ReflectionKind.Property))
+  ) {
     return opts.inverse(this);
   } else {
     return opts.fn(this);

--- a/src/theme/helpers/ifGroupContainesVisibleItems.ts
+++ b/src/theme/helpers/ifGroupContainesVisibleItems.ts
@@ -1,3 +1,4 @@
+import { ReflectionKind } from 'typedoc/dist/lib/models';
 import { ReflectionGroup } from 'typedoc/dist/lib/models/ReflectionGroup';
 import { ThemeService } from '../theme.service';
 
@@ -8,7 +9,11 @@ import { ThemeService } from '../theme.service';
  */
 export function ifGroupContainesVisibleItems(group: ReflectionGroup, opts: any) {
   const options = ThemeService.getOptions();
-  if (!options.excludePrivate || !group.allChildrenArePrivate) {
+
+  if (
+    (!options.excludePrivate || !group.allChildrenArePrivate) &&
+    (group.someChildrenAreExported || group.kind === ReflectionKind.Method || group.kind === ReflectionKind.Property)
+  ) {
     return opts.fn(this);
   } else {
     return opts.inverse(this);

--- a/src/theme/partials/header.hbs
+++ b/src/theme/partials/header.hbs
@@ -2,7 +2,7 @@
 {{#ifDisplayBreadcrumbs}}{{#unless model.isIndex}}[{{project.name}}](../README.md){{~#with model~}}{{> breadcrumb}}{{/with}}{{getNewLine}}{{/unless}}{{/ifDisplayBreadcrumbs}}
 {{!-- {{ title }} --}}
 {{~#ifDisplayMainTitle this ~}}
-# {{#unless model.isIndex }}{{model.kindString }}:{{/unless}} {{{ model.name }}}
+# {{{ model.name }}}
 {{/ifDisplayMainTitle}}
 {{#compact}}
 {{~#with model~}}

--- a/src/theme/partials/member.module.hbs
+++ b/src/theme/partials/member.module.hbs
@@ -1,5 +1,7 @@
 ## {{kindString }} {{ name }}
+{{#ifDisplayIndex this}}
 {{> index}}
+{{/ifDisplayIndex}}
 {{#each groups}}
 {{#unless allChildrenHaveOwnDocument}}
 {{> members.group }}

--- a/src/theme/templates/reflection.hbs
+++ b/src/theme/templates/reflection.hbs
@@ -1,24 +1,35 @@
 {{> header}}
-{{~#if model.displayReadme ~}}
-{{#getMarkdownFromHtml}}{{#markdown}}{{{model.readme}}}{{/markdown}}{{/getMarkdownFromHtml}}
+
+{{~#if model.displayReadme~}}
+{{#getMarkdownFromHtml}}
+{{#markdown}}
+{{{model.readme}}}
+{{/markdown}}
+{{/getMarkdownFromHtml}}
 {{~/if~}}
+
 {{getNewLine}}
 {{getNewLine}}
+
 {{~#with model~}}
 {{~#if hasComment~}}
 {{> comment}}
 {{~/if~}}
-{{~/with}}
+{{/with}}
+
 {{~#if model.typeParameters}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Type parameters
-{{~#with model}}{{> typeParameters}}{{/with}}
+
+{{#with model}}{{> typeParameters}}{{/with}}
 {{~/if}}
-{{~#if model.typeHierarchy~}}
+
+{{~#if model.typeHierarchy}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Hierarchy
 
-{{#with model.typeHierarchy~}}{{> hierarchy}}{{/with}}
+{{#with model.typeHierarchy}}{{> hierarchy}}{{/with}}
 {{getNewLine}}
-{{~/if~}}
+{{~/if}}
+
 {{~#if model.implementedTypes}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Implements
 
@@ -27,6 +38,7 @@
 {{/each}}
 {{getNewLine}}
 {{~/if}}
+
 {{~#if model.implementedBy}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Implemented by
 
@@ -35,11 +47,14 @@
 {{/each}}
 {{getNewLine}}
 {{~/if}}
+
 {{~#if model.signatures}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Callable
+
 {{#with model}}{{> member.signatures}}{{/with}}
 {{getNewLine}}
 {{~/if}}
+
 {{~#if model.indexSignature}}
 {{#getHeadingLevel '##'}}{{/getHeadingLevel}} Indexable
 
@@ -55,6 +70,7 @@
 {{~/if}}
 {{getNewLine}}
 {{~/if}}
+
 {{~#with model}}
 {{#ifDisplayIndex this}}
 {{> index}}

--- a/test/fixtures/bitbucket/README.md
+++ b/test/fixtures/bitbucket/README.md
@@ -1,5 +1,5 @@
 
-#  typedoc-plugin-markdown
+# @bigcommerce/typedoc-plugin-markdown
 
 ## Index
 
@@ -19,25 +19,17 @@
 * [Color](classes/color.md)
 * [DefaultExportedClass](classes/defaultexportedclass.md)
 * [GenericClass](classes/genericclass.md)
-* [InternalClass](classes/internalclass.md)
 * [MyFirstClass](classes/myfirstclass.md)
 * [MyFourthClass](classes/myfourthclass.md)
 * [MySecondClass](classes/mysecondclass.md)
 * [MyThirdClass](classes/mythirdclass.md)
 * [NonGenericClass](classes/nongenericclass.md)
-* [NotExportedClassName](classes/notexportedclassname.md)
 * [SubClassA](classes/subclassa.md)
 * [SubClassB](classes/subclassb.md)
 * [Vector](classes/vector.md)
-* [flattenedClass](classes/flattenedclass.md)
 
 ### Interfaces
 
-* [A](interfaces/a.md)
-* [AB](interfaces/ab.md)
-* [ABNumber](interfaces/abnumber.md)
-* [ABString](interfaces/abstring.md)
-* [B](interfaces/b.md)
 * [INameInterface](interfaces/inameinterface.md)
 * [IPrintInterface](interfaces/iprintinterface.md)
 * [IPrintNameInterface](interfaces/iprintnameinterface.md)
@@ -57,20 +49,12 @@
 * [createSomething](#markdown-header-createsomething)
 * [exportedFunction](#markdown-header-exportedfunction)
 * [fakeProtectedFunction](#markdown-header-protected-fakeprotectedfunction)
-* [flattenedCallback](#markdown-header-flattenedcallback)
-* [flattenedIndexSignature](#markdown-header-flattenedindexsignature)
-* [flattenedParameter](#markdown-header-flattenedparameter)
 * [functionWithArguments](#markdown-header-functionwitharguments)
 * [functionWithDefaults](#markdown-header-functionwithdefaults)
 * [functionWithDocLink](#markdown-header-functionwithdoclink)
 * [functionWithOptionalValue](#markdown-header-functionwithoptionalvalue)
-* [functionWithRest](#markdown-header-functionwithrest)
 * [genericFunction](#markdown-header-genericfunction)
-* [getGenericArray](#markdown-header-getgenericarray)
-* [internalFunction](#markdown-header-internalfunction)
 * [multipleSignatures](#markdown-header-multiplesignatures)
-* [testFunction](#markdown-header-testfunction)
-* [variableFunction](#markdown-header-variablefunction)
 
 ---
 

--- a/test/fixtures/bitbucket/classes/baseclass.md
+++ b/test/fixtures/bitbucket/classes/baseclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [BaseClass](../classes/baseclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [BaseClass](../classes/baseclass.md)
 
-# Class: BaseClass
+# BaseClass
 
 This is a simple base class.
 

--- a/test/fixtures/bitbucket/classes/color.md
+++ b/test/fixtures/bitbucket/classes/color.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [Color](../classes/color.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [Color](../classes/color.md)
 
-# Class: Color
+# Color
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/classes/defaultexportedclass.md
+++ b/test/fixtures/bitbucket/classes/defaultexportedclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [DefaultExportedClass](../classes/defaultexportedclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [DefaultExportedClass](../classes/defaultexportedclass.md)
 
-# Class: DefaultExportedClass
+# DefaultExportedClass
 
 This class is exported via es6 export syntax.
 

--- a/test/fixtures/bitbucket/classes/flattenedclass.md
+++ b/test/fixtures/bitbucket/classes/flattenedclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [flattenedClass](../classes/flattenedclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [flattenedClass](../classes/flattenedclass.md)
 
-# Class: flattenedClass
+# flattenedClass
 
 A class that contains members with flattened properties.
 
@@ -9,10 +9,6 @@ A class that contains members with flattened properties.
 **flattenedClass**
 
 ## Index
-
-### Constructors
-
-* [constructor](flattenedclass.md#markdown-header-constructor)
 
 ### Properties
 

--- a/test/fixtures/bitbucket/classes/genericclass.md
+++ b/test/fixtures/bitbucket/classes/genericclass.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > [GenericClass](../classes/genericclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [GenericClass](../classes/genericclass.md)
 
-# Class: GenericClass
+# GenericClass
 
 This is a generic class.
 
 ## Type parameters
+
 #### T :  [BaseClass](baseclass.md)
 
 This a type parameter.

--- a/test/fixtures/bitbucket/classes/internalclass.md
+++ b/test/fixtures/bitbucket/classes/internalclass.md
@@ -1,20 +1,17 @@
-[typedoc-plugin-markdown](../README.md) > [InternalClass](../classes/internalclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [InternalClass](../classes/internalclass.md)
 
-# Class: InternalClass
+# InternalClass
 
 This is an internal class, it is not exported.
 
 ## Type parameters
+
 #### TTT :  `keyof BaseClass`
 ## Hierarchy
 
 **InternalClass**
 
 ## Index
-
-### Constructors
-
-* [constructor](internalclass.md#markdown-header-constructor)
 
 ---
 

--- a/test/fixtures/bitbucket/classes/myfirstclass.md
+++ b/test/fixtures/bitbucket/classes/myfirstclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [MyFirstClass](../classes/myfirstclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [MyFirstClass](../classes/myfirstclass.md)
 
-# Class: MyFirstClass
+# MyFirstClass
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/classes/myfourthclass.md
+++ b/test/fixtures/bitbucket/classes/myfourthclass.md
@@ -1,8 +1,9 @@
-[typedoc-plugin-markdown](../README.md) > [MyFourthClass](../classes/myfourthclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [MyFourthClass](../classes/myfourthclass.md)
 
-# Class: MyFourthClass
+# MyFourthClass
 
 ## Type parameters
+
 #### K 
 #### V 
 ## Hierarchy

--- a/test/fixtures/bitbucket/classes/mysecondclass.md
+++ b/test/fixtures/bitbucket/classes/mysecondclass.md
@@ -1,8 +1,9 @@
-[typedoc-plugin-markdown](../README.md) > [MySecondClass](../classes/mysecondclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [MySecondClass](../classes/mysecondclass.md)
 
-# Class: MySecondClass
+# MySecondClass
 
 ## Type parameters
+
 #### T 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/classes/mythirdclass.md
+++ b/test/fixtures/bitbucket/classes/mythirdclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [MyThirdClass](../classes/mythirdclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [MyThirdClass](../classes/mythirdclass.md)
 
-# Class: MyThirdClass
+# MyThirdClass
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/classes/nongenericclass.md
+++ b/test/fixtures/bitbucket/classes/nongenericclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [NonGenericClass](../classes/nongenericclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [NonGenericClass](../classes/nongenericclass.md)
 
-# Class: NonGenericClass
+# NonGenericClass
 
 This a non generic class derived from a [generic class](genericclass.md).
 

--- a/test/fixtures/bitbucket/classes/notexportedclassname.md
+++ b/test/fixtures/bitbucket/classes/notexportedclassname.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [NotExportedClassName](../classes/notexportedclassname.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [NotExportedClassName](../classes/notexportedclassname.md)
 
-# Class: NotExportedClassName
+# NotExportedClassName
 
 This class is exported under a different name. The exported name is "ExportedClassName"
 
@@ -13,10 +13,6 @@ export {NotExportedClassName as ExportedClassName};
 **NotExportedClassName**
 
 ## Index
-
-### Constructors
-
-* [constructor](notexportedclassname.md#markdown-header-constructor)
 
 ### Properties
 

--- a/test/fixtures/bitbucket/classes/privateclass.md
+++ b/test/fixtures/bitbucket/classes/privateclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [PrivateClass](../classes/privateclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [PrivateClass](../classes/privateclass.md)
 
-# Class: PrivateClass
+# PrivateClass
 
 A class that is documented as being private.
 

--- a/test/fixtures/bitbucket/classes/subclassa.md
+++ b/test/fixtures/bitbucket/classes/subclassa.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [SubClassA](../classes/subclassa.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [SubClassA](../classes/subclassa.md)
 
-# Class: SubClassA
+# SubClassA
 
 This is a class that extends another class.
 

--- a/test/fixtures/bitbucket/classes/subclassb.md
+++ b/test/fixtures/bitbucket/classes/subclassb.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [SubClassB](../classes/subclassb.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [SubClassB](../classes/subclassb.md)
 
-# Class: SubClassB
+# SubClassB
 
 This is a class that extends another class.
 

--- a/test/fixtures/bitbucket/classes/vector.md
+++ b/test/fixtures/bitbucket/classes/vector.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [Vector](../classes/vector.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [Vector](../classes/vector.md)
 
-# Class: Vector
+# Vector
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/enums/directions.md
+++ b/test/fixtures/bitbucket/enums/directions.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [Directions](../enums/directions.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [Directions](../enums/directions.md)
 
-# Enumeration: Directions
+# Directions
 
 This is a simple Enumeration.
 

--- a/test/fixtures/bitbucket/enums/size.md
+++ b/test/fixtures/bitbucket/enums/size.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [Size](../enums/size.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [Size](../enums/size.md)
 
-# Enumeration: Size
+# Size
 
 This comment is ignored, as the enumeration is already defined.
 

--- a/test/fixtures/bitbucket/interfaces/a.md
+++ b/test/fixtures/bitbucket/interfaces/a.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > [A](../interfaces/a.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [A](../interfaces/a.md)
 
-# Interface: A
+# A
 
 A generic interface.
 
 ## Type parameters
+
 #### T 
 
 The generic type parameter.

--- a/test/fixtures/bitbucket/interfaces/ab.md
+++ b/test/fixtures/bitbucket/interfaces/ab.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > [AB](../interfaces/ab.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [AB](../interfaces/ab.md)
 
-# Interface: AB
+# AB
 
 A generic interface extending two other generic interfaces and setting one of the type parameters.
 
 ## Type parameters
+
 #### T 
 
 The leftover generic type parameter.

--- a/test/fixtures/bitbucket/interfaces/abnumber.md
+++ b/test/fixtures/bitbucket/interfaces/abnumber.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [ABNumber](../interfaces/abnumber.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [ABNumber](../interfaces/abnumber.md)
 
-# Interface: ABNumber
+# ABNumber
 
 An interface extending a generic interface and setting its type parameter.
 

--- a/test/fixtures/bitbucket/interfaces/abstring.md
+++ b/test/fixtures/bitbucket/interfaces/abstring.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [ABString](../interfaces/abstring.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [ABString](../interfaces/abstring.md)
 
-# Interface: ABString
+# ABString
 
 An interface extending a generic interface and setting its type parameter.
 

--- a/test/fixtures/bitbucket/interfaces/b.md
+++ b/test/fixtures/bitbucket/interfaces/b.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > [B](../interfaces/b.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [B](../interfaces/b.md)
 
-# Interface: B
+# B
 
 A generic interface with two type parameters.
 
 ## Type parameters
+
 #### T 
 
 The first generic type parameter.

--- a/test/fixtures/bitbucket/interfaces/inameinterface.md
+++ b/test/fixtures/bitbucket/interfaces/inameinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [INameInterface](../interfaces/inameinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [INameInterface](../interfaces/inameinterface.md)
 
-# Interface: INameInterface
+# INameInterface
 
 This is a simple interface.
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.clockconstructor.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.clockconstructor.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [ClockConstructor](../interfaces/interfaces.clockconstructor.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [ClockConstructor](../interfaces/interfaces.clockconstructor.md)
 
-# Interface: ClockConstructor
+# ClockConstructor
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.clockinterface.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.clockinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [ClockInterface](../interfaces/interfaces.clockinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [ClockInterface](../interfaces/interfaces.clockinterface.md)
 
-# Interface: ClockInterface
+# ClockInterface
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.shape.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.shape.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Shape](../interfaces/interfaces.shape.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Shape](../interfaces/interfaces.shape.md)
 
-# Interface: Shape
+# Shape
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.square.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.square.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Square](../interfaces/interfaces.square.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Square](../interfaces/interfaces.square.md)
 
-# Interface: Square
+# Square
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.squareconfig.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.squareconfig.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [SquareConfig](../interfaces/interfaces.squareconfig.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [SquareConfig](../interfaces/interfaces.squareconfig.md)
 
-# Interface: SquareConfig
+# SquareConfig
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.stringarray.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.stringarray.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [StringArray](../interfaces/interfaces.stringarray.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [StringArray](../interfaces/interfaces.stringarray.md)
 
-# Interface: StringArray
+# StringArray
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.surface.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.surface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Surface](../interfaces/interfaces.surface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md) > [Surface](../interfaces/interfaces.surface.md)
 
-# Interface: Surface
+# Surface
 
 ## Hierarchy
 

--- a/test/fixtures/bitbucket/interfaces/iprintinterface.md
+++ b/test/fixtures/bitbucket/interfaces/iprintinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [IPrintInterface](../interfaces/iprintinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [IPrintInterface](../interfaces/iprintinterface.md)
 
-# Interface: IPrintInterface
+# IPrintInterface
 
 This is a simple interface.
 

--- a/test/fixtures/bitbucket/interfaces/iprintnameinterface.md
+++ b/test/fixtures/bitbucket/interfaces/iprintnameinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [IPrintNameInterface](../interfaces/iprintnameinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [IPrintNameInterface](../interfaces/iprintnameinterface.md)
 
-# Interface: IPrintNameInterface
+# IPrintNameInterface
 
 This is a interface inheriting from two other interfaces.
 

--- a/test/fixtures/bitbucket/modules/interfaces.md
+++ b/test/fixtures/bitbucket/modules/interfaces.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [interfaces](../modules/interfaces.md)
 
-# Module: interfaces
+# interfaces
 
 ## Index
 

--- a/test/fixtures/bitbucket/modules/modulefunction.md
+++ b/test/fixtures/bitbucket/modules/modulefunction.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > [moduleFunction](../modules/modulefunction.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [moduleFunction](../modules/modulefunction.md)
 
-# Module: moduleFunction
+# moduleFunction
 
 This is the module extending the function moduleFunction().
 
 ## Callable
+
 ▸ **moduleFunction**(arg: *`string`*): `string`
 
 *Defined in [functions.ts:150](https://bitbucket.org/owner/repository_name/src/master/functions.ts?fileviewer&amp;#x3D;file-view-default#functions.ts-150)*
@@ -20,15 +21,6 @@ This is a function that is extended by a module.
 **Returns:** `string`
 
 ## Index
-
-### Variables
-
-* [functionVariable](modulefunction.md#markdown-header-functionvariable)
-
-### Functions
-
-* [append](modulefunction.md#markdown-header-append)
-* [prepend](modulefunction.md#markdown-header-prepend)
 
 ---
 

--- a/test/fixtures/bitbucket/modules/privatemodule.md
+++ b/test/fixtures/bitbucket/modules/privatemodule.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > [PrivateModule](../modules/privatemodule.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > [PrivateModule](../modules/privatemodule.md)
 
-# Module: PrivateModule
+# PrivateModule
 
 A module that is documented as being private.
 

--- a/test/fixtures/gitbook/classes/_access_.privateclass.md
+++ b/test/fixtures/gitbook/classes/_access_.privateclass.md
@@ -14,7 +14,7 @@ A class that is documented as being private.
 
 **● fakePrivateVariable**: *`string`*
 
-*Defined in [access.ts:41](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L41)*
+*Defined in [access.ts:41](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L41)*
 
 A variable that is made private via comment.
 
@@ -25,7 +25,7 @@ ___
 
 **● fakeProtectedVariable**: *`string`*
 
-*Defined in [access.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L47)*
+*Defined in [access.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L47)*
 
 A variable that is made protected via comment.
 
@@ -39,7 +39,7 @@ ___
 
 ▸ **fakePrivateFunction**(): `void`
 
-*Defined in [access.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L53)*
+*Defined in [access.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L53)*
 
 A function that is made private via comment.
 
@@ -52,7 +52,7 @@ ___
 
 ▸ **fakeProtectedFunction**(): `void`
 
-*Defined in [access.ts:59](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L59)*
+*Defined in [access.ts:59](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L59)*
 
 A function that is made protected via comment.
 

--- a/test/fixtures/gitbook/classes/_classes_.baseclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.baseclass.md
@@ -28,7 +28,7 @@ This is a simple example on how to use BaseClass.
 
 ⊕ **new BaseClass**(source: *[BaseClass](_classes_.baseclass.md)*): [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 **Parameters:**
 
@@ -38,7 +38,7 @@ This is a simple example on how to use BaseClass.
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:81](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
+*Defined in [classes.ts:81](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
 
 **Parameters:**
 
@@ -58,7 +58,7 @@ ___
 
 **● internalClass**: *[InternalClass](_classes_.internalclass.md)<`keyof BaseClass`>*
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 This is an instance member of an internal class.
 
@@ -69,7 +69,7 @@ ___
 
 **● kind**: *`number`*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -82,7 +82,7 @@ ___
 
 *Implementation of [INameInterface](../interfaces/_classes_.inameinterface.md).[name](../interfaces/_classes_.inameinterface.md#name)*
 
-*Defined in [classes.ts:60](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L60)*
+*Defined in [classes.ts:60](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L60)*
 
 This is a simple public member.
 
@@ -93,7 +93,7 @@ ___
 
 **● instance**: *[BaseClass](_classes_.baseclass.md)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -106,7 +106,7 @@ ___
 
 **● instances**: *[BaseClass](_classes_.baseclass.md)[]*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **abstractMethod**(): `void`
 
-*Defined in [classes.ts:95](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L95)*
+*Defined in [classes.ts:95](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L95)*
 
 **Returns:** `void`
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **arrowFunction**(param2: *`string`*, param1: *`number`*): `void`
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **checkName**(): `boolean`
 
-*Defined in [classes.ts:150](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L150)*
+*Defined in [classes.ts:150](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L150)*
 
 This is a private function.
 
@@ -164,7 +164,7 @@ ___
 
 *Implementation of [INameInterface](../interfaces/_classes_.inameinterface.md).[getName](../interfaces/_classes_.inameinterface.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **setName**(name: *`string`*): `void`
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -201,7 +201,7 @@ ___
 
 ▸ **caTest**(originalValues: *[BaseClass](_classes_.baseclass.md)*, newRecord: *`any`*, fieldNames: *`string`[]*, mandatoryFields: *`string`[]*): `string`
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -223,7 +223,7 @@ ___
 
 ▸ **getInstance**(): [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **getName**(): `string`
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/gitbook/classes/_classes_.genericclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.genericclass.md
@@ -3,6 +3,7 @@
 This is a generic class.
 
 # Type parameters
+
 #### T :  [BaseClass](_classes_.baseclass.md)
 
 This a type parameter.
@@ -21,7 +22,7 @@ This a type parameter.
 
 ⊕ **new GenericClass**(p1: *`any`*, p2: *`T`*, p3: *`number`*, p4: *`number`*, p5: *`string`*): [GenericClass](_classes_.genericclass.md)
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -47,7 +48,7 @@ ___
 
 **● p2**: *`T`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -58,7 +59,7 @@ ___
 
 **● p3**: *`number`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -69,7 +70,7 @@ ___
 
 **● p4**: *`number`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public implicit any property
 
@@ -80,7 +81,7 @@ ___
 
 **● p5**: *`string`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -91,7 +92,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -103,7 +104,7 @@ ___
 
 ▸ **getValue**(): `T`
 
-*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
+*Defined in [classes.ts:314](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** `T`
 
@@ -114,7 +115,7 @@ ___
 
 ▸ **setValue**(value: *`T`*): `void`
 
-*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
+*Defined in [classes.ts:310](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_classes_.internalclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.internalclass.md
@@ -3,6 +3,7 @@
 This is an internal class, it is not exported.
 
 # Type parameters
+
 #### TTT :  `keyof BaseClass`
 # Hierarchy
 
@@ -16,7 +17,7 @@ This is an internal class, it is not exported.
 
 ⊕ **new InternalClass**(options: *`object`*): [InternalClass](_classes_.internalclass.md)
 
-*Defined in [classes.ts:187](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L187)*
+*Defined in [classes.ts:187](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L187)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_classes_.nongenericclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.nongenericclass.md
@@ -18,7 +18,7 @@ This a non generic class derived from a [generic class](_classes_.genericclass.m
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[constructor](_classes_.genericclass.md#constructor)*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p2](_classes_.genericclass.md#p2)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -59,7 +59,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p3](_classes_.genericclass.md#p3)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p5](_classes_.genericclass.md#p5)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[value](_classes_.genericclass.md#value)*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[getValue](_classes_.genericclass.md#getvalue)*
 
-*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
+*Defined in [classes.ts:314](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -112,7 +112,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[setValue](_classes_.genericclass.md#setvalue)*
 
-*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
+*Defined in [classes.ts:310](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_classes_.subclassa.md
+++ b/test/fixtures/gitbook/classes/_classes_.subclassa.md
@@ -27,7 +27,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 **Parameters:**
 
@@ -39,7 +39,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:81](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
+*Defined in [classes.ts:81](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[kind](_classes_.baseclass.md#kind)*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -76,7 +76,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[name](_classes_.baseclass.md#name)*
 
-*Defined in [classes.ts:200](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L200)*
+*Defined in [classes.ts:200](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L200)*
 
 ___
 <a id="instance"></a>
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instance](_classes_.baseclass.md#instance)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -102,7 +102,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instances](_classes_.baseclass.md#instances)*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -114,14 +114,14 @@ ___
 
 getnameProperty(): `string`setnameProperty(value: *`string`*): `void`
 
-*Defined in [classes.ts:219](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
+*Defined in [classes.ts:219](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
 
 Returns the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
 **Returns:** `string`
 The return value.
 
-*Defined in [classes.ts:229](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L229)*
+*Defined in [classes.ts:229](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L229)*
 
 Sets the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -141,7 +141,7 @@ ___
 
 getreadOnlyNameProperty(): `string`
 
-*Defined in [classes.ts:238](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
+*Defined in [classes.ts:238](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
 
 Returns the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -155,7 +155,7 @@ ___
 
 setwriteOnlyNameProperty(value: *`string`*): `void`
 
-*Defined in [classes.ts:248](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
+*Defined in [classes.ts:248](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
 
 Sets the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -180,7 +180,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[abstractMethod](_classes_.baseclass.md#abstractmethod)*
 
-*Defined in [classes.ts:252](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L252)*
+*Defined in [classes.ts:252](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L252)*
 
 **Returns:** `void`
 
@@ -193,7 +193,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[arrowFunction](_classes_.baseclass.md#arrowfunction)*
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -217,7 +217,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -235,7 +235,7 @@ ___
 
 *Implementation of [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md).[print](../interfaces/_classes_.iprintnameinterface.md#print)*
 
-*Defined in [classes.ts:205](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L205)*
+*Defined in [classes.ts:205](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L205)*
 
 This is a simple interface function.
 
@@ -256,7 +256,7 @@ ___
 
 *Implementation of [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md).[printName](../interfaces/_classes_.iprintnameinterface.md#printname)*
 
-*Defined in [classes.ts:210](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L210)*
+*Defined in [classes.ts:210](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L210)*
 
 This is a interface function of IPrintNameInterface
 
@@ -271,7 +271,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[setName](_classes_.baseclass.md#setname)*
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[caTest](_classes_.baseclass.md#catest)*
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -318,7 +318,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getInstance](_classes_.baseclass.md#getinstance)*
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -336,7 +336,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname-1)*
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/gitbook/classes/_classes_.subclassb.md
+++ b/test/fixtures/gitbook/classes/_classes_.subclassb.md
@@ -24,7 +24,7 @@ The constructor of the original class should be overwritten.
 
 *Overrides [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:263](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
+*Defined in [classes.ts:263](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
 
 **Parameters:**
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[kind](_classes_.baseclass.md#kind)*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -61,7 +61,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[name](_classes_.baseclass.md#name)*
 
-*Defined in [classes.ts:263](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
+*Defined in [classes.ts:263](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
 
 ___
 <a id="instance"></a>
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instance](_classes_.baseclass.md#instance)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instances](_classes_.baseclass.md#instances)*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[abstractMethod](_classes_.baseclass.md#abstractmethod)*
 
-*Defined in [classes.ts:269](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L269)*
+*Defined in [classes.ts:269](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L269)*
 
 **Returns:** `void`
 
@@ -114,7 +114,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[arrowFunction](_classes_.baseclass.md#arrowfunction)*
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **doOtherThings**(value: * `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)*, secondValue?: *[SubClassA](_classes_.subclassa.md)*): `void`
 
-*Defined in [classes.ts:282](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
+*Defined in [classes.ts:282](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
 
 Description for doOtherThings.
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **doSomething**(value: *[`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)]*): `void`
 
-*Defined in [classes.ts:273](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L273)*
+*Defined in [classes.ts:273](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L273)*
 
 **Parameters:**
 
@@ -175,7 +175,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -193,7 +193,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[setName](_classes_.baseclass.md#setname)*
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -216,7 +216,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[caTest](_classes_.baseclass.md#catest)*
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -240,7 +240,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getInstance](_classes_.baseclass.md#getinstance)*
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname-1)*
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/gitbook/classes/_default_export_.defaultexportedclass.md
+++ b/test/fixtures/gitbook/classes/_default_export_.defaultexportedclass.md
@@ -18,7 +18,7 @@ export default class DefaultExportedClass {}
 
 ⊕ **new DefaultExportedClass**(): [DefaultExportedClass](_default_export_.defaultexportedclass.md)
 
-*Defined in [default-export.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
+*Defined in [default-export.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
 
 This is the constructor of the default exported class.
 
@@ -34,7 +34,7 @@ ___
 
 **● exportedProperty**: *`string`*
 
-*Defined in [default-export.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
+*Defined in [default-export.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
 
 Property of default exported class.
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **getExportedProperty**(): `string`
 
-*Defined in [default-export.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L62)*
+*Defined in [default-export.ts:62](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L62)*
 
 Method of default exported class.
 

--- a/test/fixtures/gitbook/classes/_default_export_.notexportedclassname.md
+++ b/test/fixtures/gitbook/classes/_default_export_.notexportedclassname.md
@@ -18,7 +18,7 @@ export {NotExportedClassName as ExportedClassName};
 
 ⊕ **new NotExportedClassName**(): [NotExportedClassName](_default_export_.notexportedclassname.md)
 
-*Defined in [default-export.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
+*Defined in [default-export.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
 
 This is the constructor of the NotExportedClassName class.
 
@@ -34,7 +34,7 @@ ___
 
 **● notExportedProperty**: *`string`*
 
-*Defined in [default-export.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
+*Defined in [default-export.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
 
 Property of NotExportedClassName class.
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **getNotExportedProperty**(): `string`
 
-*Defined in [default-export.ts:33](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L33)*
+*Defined in [default-export.ts:33](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L33)*
 
 Method of NotExportedClassName class.
 

--- a/test/fixtures/gitbook/classes/_flattened_.flattenedclass.md
+++ b/test/fixtures/gitbook/classes/_flattened_.flattenedclass.md
@@ -14,7 +14,7 @@ A class that contains members with flattened properties.
 
 ⊕ **new flattenedClass**(options: *`object`*): [flattenedClass](_flattened_.flattenedclass.md)
 
-*Defined in [flattened.ts:64](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L64)*
+*Defined in [flattened.ts:64](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L64)*
 
 A constructor that accepts an option object defined inline.
 
@@ -36,7 +36,7 @@ ___
 
 **● callback**: *`function`*
 
-*Defined in [flattened.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L35)*
+*Defined in [flattened.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L35)*
 
 A member that holds a callback that requires a typed function signature.
 
@@ -59,7 +59,7 @@ ___
 
 **● indexed**: *`object`*
 
-*Defined in [flattened.ts:43](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L43)*
+*Defined in [flattened.ts:43](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L43)*
 
 A member that holds an index signature.
 
@@ -82,7 +82,7 @@ ___
 
 **● multipleCallSignatures**: *`function`*
 
-*Defined in [flattened.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L52)*
+*Defined in [flattened.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L52)*
 
 An object with multiple call signatures.
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/27](https://github.com/sebastian-lenz/typedoc/issues/27)
@@ -113,7 +113,7 @@ ___
 
 **● options**: *`object`*
 
-*Defined in [flattened.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L21)*
+*Defined in [flattened.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L21)*
 
 A member that accepts an option object defined inline.
 

--- a/test/fixtures/gitbook/classes/_generics_.myfourthclass.md
+++ b/test/fixtures/gitbook/classes/_generics_.myfourthclass.md
@@ -1,6 +1,7 @@
 
 
 # Type parameters
+
 #### K 
 #### V 
 # Hierarchy

--- a/test/fixtures/gitbook/classes/_generics_.mysecondclass.md
+++ b/test/fixtures/gitbook/classes/_generics_.mysecondclass.md
@@ -1,6 +1,7 @@
 
 
 # Type parameters
+
 #### T 
 # Hierarchy
 

--- a/test/fixtures/gitbook/classes/_generics_.mythirdclass.md
+++ b/test/fixtures/gitbook/classes/_generics_.mythirdclass.md
@@ -12,7 +12,7 @@
 
 ⊕ **new MyThirdClass**(arg: *[MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>>*): [MyThirdClass](_generics_.mythirdclass.md)
 
-*Defined in [generics.ts:93](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L93)*
+*Defined in [generics.ts:93](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L93)*
 
 **Parameters:**
 
@@ -32,7 +32,7 @@ ___
 
 **● arg**: *[MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>>*
 
-*Defined in [generics.ts:94](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L94)*
+*Defined in [generics.ts:94](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L94)*
 
 ___
 

--- a/test/fixtures/gitbook/classes/_interfaces_.color.md
+++ b/test/fixtures/gitbook/classes/_interfaces_.color.md
@@ -12,7 +12,7 @@
 
 ⊕ **new Color**(r: *`number`*, g: *`number`*, b: *`number`*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:24](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L24)*
+*Defined in [interfaces.ts:24](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L24)*
 
 **Parameters:**
 
@@ -34,7 +34,7 @@ ___
 
 **● b**: *`number`*
 
-*Defined in [interfaces.ts:27](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L27)*
+*Defined in [interfaces.ts:27](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L27)*
 
 ___
 <a id="g"></a>
@@ -43,7 +43,7 @@ ___
 
 **● g**: *`number`*
 
-*Defined in [interfaces.ts:26](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L26)*
+*Defined in [interfaces.ts:26](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L26)*
 
 ___
 <a id="r"></a>
@@ -52,7 +52,7 @@ ___
 
 **● r**: *`number`*
 
-*Defined in [interfaces.ts:25](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L25)*
+*Defined in [interfaces.ts:25](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L25)*
 
 ___
 <a id="background"></a>
@@ -61,7 +61,7 @@ ___
 
 **● background**: *[Color](_interfaces_.color.md)* =  Color.black
 
-*Defined in [interfaces.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L35)*
+*Defined in [interfaces.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L35)*
 
 ___
 <a id="black"></a>
@@ -70,7 +70,7 @@ ___
 
 **● black**: *[Color](_interfaces_.color.md)* =  new Color(0.0, 0.0, 0.0)
 
-*Defined in [interfaces.ts:34](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L34)*
+*Defined in [interfaces.ts:34](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L34)*
 
 ___
 <a id="defaultcolor"></a>
@@ -79,7 +79,7 @@ ___
 
 **● defaultColor**: *[Color](_interfaces_.color.md)* =  Color.black
 
-*Defined in [interfaces.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L36)*
+*Defined in [interfaces.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L36)*
 
 ___
 <a id="grey"></a>
@@ -88,7 +88,7 @@ ___
 
 **● grey**: *[Color](_interfaces_.color.md)* =  new Color(0.5, 0.5, 0.5)
 
-*Defined in [interfaces.ts:33](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L33)*
+*Defined in [interfaces.ts:33](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L33)*
 
 ___
 <a id="white"></a>
@@ -97,7 +97,7 @@ ___
 
 **● white**: *[Color](_interfaces_.color.md)* =  new Color(1.0, 1.0, 1.0)
 
-*Defined in [interfaces.ts:32](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L32)*
+*Defined in [interfaces.ts:32](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L32)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 ▸ **plus**(v1: *[Color](_interfaces_.color.md)*, v2: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L30)*
+*Defined in [interfaces.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L30)*
 
 **Parameters:**
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **scale**(k: *`number`*, v: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:29](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L29)*
+*Defined in [interfaces.ts:29](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L29)*
 
 **Parameters:**
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **times**(v1: *[Color](_interfaces_.color.md)*, v2: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:31](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L31)*
+*Defined in [interfaces.ts:31](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L31)*
 
 **Parameters:**
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **toDrawingColor**(c: *[Color](_interfaces_.color.md)*): `object`
 
-*Defined in [interfaces.ts:37](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L37)*
+*Defined in [interfaces.ts:37](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L37)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_interfaces_.vector.md
+++ b/test/fixtures/gitbook/classes/_interfaces_.vector.md
@@ -12,7 +12,7 @@
 
 ⊕ **new Vector**(x: *`number`*, y: *`number`*, z: *`number`*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:2](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L2)*
+*Defined in [interfaces.ts:2](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L2)*
 
 **Parameters:**
 
@@ -34,7 +34,7 @@ ___
 
 **● x**: *`number`*
 
-*Defined in [interfaces.ts:3](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L3)*
+*Defined in [interfaces.ts:3](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L3)*
 
 ___
 <a id="y"></a>
@@ -43,7 +43,7 @@ ___
 
 **● y**: *`number`*
 
-*Defined in [interfaces.ts:4](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L4)*
+*Defined in [interfaces.ts:4](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L4)*
 
 ___
 <a id="z"></a>
@@ -52,7 +52,7 @@ ___
 
 **● z**: *`number`*
 
-*Defined in [interfaces.ts:5](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L5)*
+*Defined in [interfaces.ts:5](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L5)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **cross**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:17](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L17)*
+*Defined in [interfaces.ts:17](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L17)*
 
 **Parameters:**
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **dot**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): `number`
 
-*Defined in [interfaces.ts:10](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L10)*
+*Defined in [interfaces.ts:10](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L10)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **mag**(v: *[Vector](_interfaces_.vector.md)*): `number`
 
-*Defined in [interfaces.ts:11](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L11)*
+*Defined in [interfaces.ts:11](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L11)*
 
 **Parameters:**
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **minus**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:8](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L8)*
+*Defined in [interfaces.ts:8](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L8)*
 
 **Parameters:**
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **norm**(v: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:12](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L12)*
+*Defined in [interfaces.ts:12](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L12)*
 
 **Parameters:**
 
@@ -152,7 +152,7 @@ ___
 
 ▸ **plus**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L9)*
+*Defined in [interfaces.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L9)*
 
 **Parameters:**
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **times**(k: *`number`*, v: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:7](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L7)*
+*Defined in [interfaces.ts:7](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L7)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/enums/_enumerations_.directions.md
+++ b/test/fixtures/gitbook/enums/_enumerations_.directions.md
@@ -23,7 +23,7 @@ This is a simple Enumeration.
 
 **Bottom**: 
 
-*Defined in [enumerations.ts:25](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L25)*
+*Defined in [enumerations.ts:25](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L25)*
 
 A simple enum member.
 
@@ -34,7 +34,7 @@ ___
 
 **Left**: 
 
-*Defined in [enumerations.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L30)*
+*Defined in [enumerations.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L30)*
 
 A simple enum member.
 
@@ -45,7 +45,7 @@ ___
 
 **Right**: 
 
-*Defined in [enumerations.ts:20](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L20)*
+*Defined in [enumerations.ts:20](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L20)*
 
 A simple enum member.
 
@@ -56,7 +56,7 @@ ___
 
 **Top**: 
 
-*Defined in [enumerations.ts:15](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L15)*
+*Defined in [enumerations.ts:15](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L15)*
 
 A simple enum member.
 
@@ -67,7 +67,7 @@ ___
 
 **TopLeft**:  =  Top | Left
 
-*Defined in [enumerations.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L35)*
+*Defined in [enumerations.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L35)*
 
 A composite enum member.
 
@@ -78,7 +78,7 @@ ___
 
 **TopRight**:  =  Top | Right
 
-*Defined in [enumerations.ts:40](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L40)*
+*Defined in [enumerations.ts:40](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L40)*
 
 A composite enum member.
 

--- a/test/fixtures/gitbook/enums/_enumerations_.size.md
+++ b/test/fixtures/gitbook/enums/_enumerations_.size.md
@@ -28,7 +28,7 @@ This comment is ignored, as the enumeration is already defined.
 
 **Large**: 
 
-*Defined in [enumerations.ts:57](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L57)*
+*Defined in [enumerations.ts:57](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L57)*
 
 A simple enum member.
 
@@ -39,7 +39,7 @@ ___
 
 **Medium**: 
 
-*Defined in [enumerations.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L52)*
+*Defined in [enumerations.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L52)*
 
 A simple enum member.
 
@@ -50,7 +50,7 @@ ___
 
 **Small**: 
 
-*Defined in [enumerations.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L47)*
+*Defined in [enumerations.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L47)*
 
 A simple enum member.
 
@@ -64,7 +64,7 @@ ___
 
 **● defaultSize**: *[Size](_enumerations_.size.md)* =  Size.Medium
 
-*Defined in [enumerations.ts:68](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L68)*
+*Defined in [enumerations.ts:68](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L68)*
 
 A variable that is attached to an enumeration.
 
@@ -78,7 +78,7 @@ ___
 
 ▸ **isSmall**(value: *[Size](_enumerations_.size.md)*): `boolean`
 
-*Defined in [enumerations.ts:77](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L77)*
+*Defined in [enumerations.ts:77](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L77)*
 
 A function that is attached to an enumeration.
 

--- a/test/fixtures/gitbook/interfaces/_classes_.inameinterface.md
+++ b/test/fixtures/gitbook/interfaces/_classes_.inameinterface.md
@@ -22,7 +22,7 @@ This is a simple interface.
 
 **● name**: *`string`*
 
-*Defined in [classes.ts:16](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
+*Defined in [classes.ts:16](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
 
 This is a interface member of INameInterface.
 
@@ -38,7 +38,7 @@ ___
 
 ▸ **getName**(): `string`
 
-*Defined in [classes.ts:23](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
+*Defined in [classes.ts:23](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
 
 This is a interface function of INameInterface.
 

--- a/test/fixtures/gitbook/interfaces/_classes_.iprintinterface.md
+++ b/test/fixtures/gitbook/interfaces/_classes_.iprintinterface.md
@@ -16,7 +16,7 @@ This is a simple interface.
 
 ▸ **print**(value: *`string`*): `void`
 
-*Defined in [classes.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
+*Defined in [classes.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
 
 This is a interface function of IPrintInterface
 

--- a/test/fixtures/gitbook/interfaces/_classes_.iprintnameinterface.md
+++ b/test/fixtures/gitbook/interfaces/_classes_.iprintnameinterface.md
@@ -24,7 +24,7 @@ This is a interface inheriting from two other interfaces.
 
 *Inherited from [INameInterface](_classes_.inameinterface.md).[name](_classes_.inameinterface.md#name)*
 
-*Defined in [classes.ts:16](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
+*Defined in [classes.ts:16](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
 
 This is a interface member of INameInterface.
 
@@ -42,7 +42,7 @@ ___
 
 *Inherited from [INameInterface](_classes_.inameinterface.md).[getName](_classes_.inameinterface.md#getname)*
 
-*Defined in [classes.ts:23](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
+*Defined in [classes.ts:23](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
 
 This is a interface function of INameInterface.
 
@@ -59,7 +59,7 @@ ___
 
 *Inherited from [IPrintInterface](_classes_.iprintinterface.md).[print](_classes_.iprintinterface.md#print)*
 
-*Defined in [classes.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
+*Defined in [classes.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
 
 This is a interface function of IPrintInterface
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **printName**(): `void`
 
-*Defined in [classes.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L47)*
+*Defined in [classes.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L47)*
 
 This is a interface function of IPrintNameInterface
 

--- a/test/fixtures/gitbook/interfaces/_generics_.a.md
+++ b/test/fixtures/gitbook/interfaces/_generics_.a.md
@@ -3,6 +3,7 @@
 A generic interface.
 
 # Type parameters
+
 #### T 
 
 The generic type parameter.
@@ -21,7 +22,7 @@ The generic type parameter.
 
 ▸ **getT**(): `T`
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 

--- a/test/fixtures/gitbook/interfaces/_generics_.ab.md
+++ b/test/fixtures/gitbook/interfaces/_generics_.ab.md
@@ -3,6 +3,7 @@
 A generic interface extending two other generic interfaces and setting one of the type parameters.
 
 # Type parameters
+
 #### T 
 
 The leftover generic type parameter.
@@ -29,7 +30,7 @@ The leftover generic type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -45,7 +46,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -61,7 +62,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/gitbook/interfaces/_generics_.abnumber.md
+++ b/test/fixtures/gitbook/interfaces/_generics_.abnumber.md
@@ -18,7 +18,7 @@ An interface extending a generic interface and setting its type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -34,7 +34,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -50,7 +50,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/gitbook/interfaces/_generics_.abstring.md
+++ b/test/fixtures/gitbook/interfaces/_generics_.abstring.md
@@ -18,7 +18,7 @@ An interface extending a generic interface and setting its type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -34,7 +34,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -50,7 +50,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/gitbook/interfaces/_generics_.b.md
+++ b/test/fixtures/gitbook/interfaces/_generics_.b.md
@@ -3,6 +3,7 @@
 A generic interface with two type parameters.
 
 # Type parameters
+
 #### T 
 
 The first generic type parameter.
@@ -25,7 +26,7 @@ The second generic type parameter.
 
 ▸ **getC**(): `C`
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -39,7 +40,7 @@ ___
 
 ▸ **setT**(value: *`T`*): `void`
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockconstructor.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockconstructor.md
@@ -12,7 +12,7 @@
 
 ⊕ **new ClockConstructor**(hour: *`number`*, minute: *`number`*): [ClockInterface](_interfaces_.interfaces.clockinterface.md)
 
-*Defined in [interfaces.ts:79](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L79)*
+*Defined in [interfaces.ts:79](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L79)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockinterface.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockinterface.md
@@ -12,7 +12,7 @@
 
 **● currentTime**: *`Date`*
 
-*Defined in [interfaces.ts:75](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L75)*
+*Defined in [interfaces.ts:75](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L75)*
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 ▸ **setTime**(d: *`Date`*): `any`
 
-*Defined in [interfaces.ts:76](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L76)*
+*Defined in [interfaces.ts:76](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L76)*
 
 **Parameters:**
 
@@ -41,7 +41,7 @@ ___
 
 ▸ **tick**(): `any`
 
-*Defined in [interfaces.ts:83](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L83)*
+*Defined in [interfaces.ts:83](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L83)*
 
 **Returns:** `any`
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.shape.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.shape.md
@@ -14,7 +14,7 @@
 
 **● color**: *`string`*
 
-*Defined in [interfaces.ts:91](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
+*Defined in [interfaces.ts:91](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
 
 ___
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.square.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.square.md
@@ -16,7 +16,7 @@
 
 *Inherited from [Shape](_interfaces_.interfaces.shape.md).[color](_interfaces_.interfaces.shape.md#color)*
 
-*Defined in [interfaces.ts:91](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
+*Defined in [interfaces.ts:91](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
 
 ___
 <a id="sidelength"></a>
@@ -25,7 +25,7 @@ ___
 
 **● sideLength**: *`number`*
 
-*Defined in [interfaces.ts:95](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L95)*
+*Defined in [interfaces.ts:95](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L95)*
 
 ___
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.squareconfig.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.squareconfig.md
@@ -12,7 +12,7 @@
 
 **● color**: *`string`*
 
-*Defined in [interfaces.ts:57](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L57)*
+*Defined in [interfaces.ts:57](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L57)*
 
 ___
 <a id="width"></a>
@@ -21,7 +21,7 @@ ___
 
 **● width**: *`number`*
 
-*Defined in [interfaces.ts:58](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L58)*
+*Defined in [interfaces.ts:58](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L58)*
 
 ___
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.surface.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.surface.md
@@ -12,7 +12,7 @@
 
 **● diffuse**: *`function`*
 
-*Defined in [interfaces.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L50)*
+*Defined in [interfaces.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L50)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): [Color](../classes/_interfaces_.color.md)
@@ -32,7 +32,7 @@ ___
 
 **● reflect**: *`function`*
 
-*Defined in [interfaces.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L52)*
+*Defined in [interfaces.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L52)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): `number`
@@ -52,7 +52,7 @@ ___
 
 **● roughness**: *`number`*
 
-*Defined in [interfaces.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L53)*
+*Defined in [interfaces.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L53)*
 
 ___
 <a id="specular"></a>
@@ -61,7 +61,7 @@ ___
 
 **● specular**: *`function`*
 
-*Defined in [interfaces.ts:51](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L51)*
+*Defined in [interfaces.ts:51](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L51)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): [Color](../classes/_interfaces_.color.md)

--- a/test/fixtures/gitbook/modules/_access_.md
+++ b/test/fixtures/gitbook/modules/_access_.md
@@ -10,7 +10,7 @@ Examples taken from the TypeDoc 'access' examples directory ([https://github.com
 
 **● fakePrivateVariable**: *`string`* = "test"
 
-*Defined in [access.ts:12](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L12)*
+*Defined in [access.ts:12](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L12)*
 
 A variable that is made private via comment.
 
@@ -21,7 +21,7 @@ ___
 
 **● fakeProtectedVariable**: *`string`* = "test"
 
-*Defined in [access.ts:18](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L18)*
+*Defined in [access.ts:18](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L18)*
 
 A variable that is made protected via comment.
 
@@ -35,7 +35,7 @@ ___
 
 ▸ **fakePrivateFunction**(): `void`
 
-*Defined in [access.ts:24](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L24)*
+*Defined in [access.ts:24](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L24)*
 
 A function that is made private via comment.
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **fakeProtectedFunction**(): `void`
 
-*Defined in [access.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L30)*
+*Defined in [access.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L30)*
 
 A function that is made protected via comment.
 

--- a/test/fixtures/gitbook/modules/_access_.privatemodule.md
+++ b/test/fixtures/gitbook/modules/_access_.privatemodule.md
@@ -18,7 +18,7 @@ A module that is documented as being private.
 
 ▸ **functionInsidePrivateModule**(): `void`
 
-*Defined in [access.ts:67](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L67)*
+*Defined in [access.ts:67](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L67)*
 
 **Returns:** `void`
 

--- a/test/fixtures/gitbook/modules/_classes_.md
+++ b/test/fixtures/gitbook/modules/_classes_.md
@@ -8,7 +8,6 @@ Examples taken from the TypeDoc 'classes' examples directory ([https://github.co
 
 * [BaseClass](../classes/_classes_.baseclass.md)
 * [GenericClass](../classes/_classes_.genericclass.md)
-* [InternalClass](../classes/_classes_.internalclass.md)
 * [NonGenericClass](../classes/_classes_.nongenericclass.md)
 * [SubClassA](../classes/_classes_.subclassa.md)
 * [SubClassB](../classes/_classes_.subclassb.md)

--- a/test/fixtures/gitbook/modules/_default_export_.md
+++ b/test/fixtures/gitbook/modules/_default_export_.md
@@ -7,7 +7,6 @@ Examples taken from the TypeDoc 'default-export' examples directory ([https://gi
 ### Classes
 
 * [DefaultExportedClass](../classes/_default_export_.defaultexportedclass.md)
-* [NotExportedClassName](../classes/_default_export_.notexportedclassname.md)
 
 ---
 

--- a/test/fixtures/gitbook/modules/_doc_comments_.md
+++ b/test/fixtures/gitbook/modules/_doc_comments_.md
@@ -8,7 +8,7 @@
 
 **● commentsWithTags**: *`boolean`* = false
 
-*Defined in [doc-comments.ts:27](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L27)*
+*Defined in [doc-comments.ts:27](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L27)*
 
 *__name__*: AbstractMetadataModule
 
@@ -33,7 +33,7 @@ ___
 
 **● generalComments**: *`boolean`* = false
 
-*Defined in [doc-comments.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L9)*
+*Defined in [doc-comments.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L9)*
 
 Additionally you can link to other classes, members or functions using double square brackets.
 

--- a/test/fixtures/gitbook/modules/_flattened_.md
+++ b/test/fixtures/gitbook/modules/_flattened_.md
@@ -4,16 +4,6 @@ Examples taken from the TypeDoc 'flattened' examples directory ([https://github.
 
 # Index
 
-### Classes
-
-* [flattenedClass](../classes/_flattened_.flattenedclass.md)
-
-### Functions
-
-* [flattenedCallback](_flattened_.md#flattenedcallback)
-* [flattenedIndexSignature](_flattened_.md#flattenedindexsignature)
-* [flattenedParameter](_flattened_.md#flattenedparameter)
-
 ---
 
 # Functions
@@ -24,7 +14,7 @@ Examples taken from the TypeDoc 'flattened' examples directory ([https://github.
 
 ▸ **flattenedCallback**(callback: *`function`*): `void`
 
-*Defined in [flattened.ts:93](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L93)*
+*Defined in [flattened.ts:93](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L93)*
 
 A function that has a parameter that requires a typed function callback.
 
@@ -43,7 +33,7 @@ ___
 
 ▸ **flattenedIndexSignature**(indexed: *`object`*): `void`
 
-*Defined in [flattened.ts:122](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L122)*
+*Defined in [flattened.ts:122](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L122)*
 
 A function that accepts an index signature parameter.
 
@@ -62,7 +52,7 @@ ___
 
 ▸ **flattenedParameter**(options: *`object`*): `void`
 
-*Defined in [flattened.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L105)*
+*Defined in [flattened.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L105)*
 
 A function that accepts an option object defined inline.
 

--- a/test/fixtures/gitbook/modules/_functions_.md
+++ b/test/fixtures/gitbook/modules/_functions_.md
@@ -8,7 +8,7 @@
 
 ▸ **createSomething**(): `object`
 
-*Defined in [functions.ts:183](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L183)*
+*Defined in [functions.ts:183](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L183)*
 
 A function that returns an object. Also no type information is given, the object should be correctly reflected.
 
@@ -21,7 +21,7 @@ ___
 
 ▸ **exportedFunction**(): `void`
 
-*Defined in [functions.ts:19](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L19)*
+*Defined in [functions.ts:19](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L19)*
 
 This is a simple exported function.
 
@@ -34,7 +34,7 @@ ___
 
 ▸ **functionWithArguments**(paramZ: *`string`*, paramG: *`any`*, paramA: *[INameInterface](../interfaces/_classes_.inameinterface.md)*): `number`
 
-*Defined in [functions.ts:59](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L59)*
+*Defined in [functions.ts:59](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L59)*
 
 This is a function with multiple arguments and a return value.
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **functionWithDefaults**(valueA?: *`string`*, valueB?: *`number`*, valueC?: *`number`*, valueD?: *`boolean`*, valueE?: *`boolean`*): `string`
 
-*Defined in [functions.ts:79](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L79)*
+*Defined in [functions.ts:79](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L79)*
 
 This is a function with a parameter that has a default value.
 
@@ -79,7 +79,7 @@ ___
 
 ▸ **functionWithDocLink**(): `void`
 
-*Defined in [functions.ts:199](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L199)*
+*Defined in [functions.ts:199](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L199)*
 
 See [`INameInterface`](../interfaces/_classes_.inameinterface.md) and [INameInterface's name property](../interfaces/_classes_.inameinterface.md#name). Also, check out [Google](http://www.google.com) and [GitHub](https://github.com).
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **functionWithOptionalValue**(requiredParam: *`string`*, optionalParam?: *`string`*): `void`
 
-*Defined in [functions.ts:70](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L70)*
+*Defined in [functions.ts:70](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L70)*
 
 This is a function with a parameter that is optional.
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **functionWithRest**(...rest: *`string`[]*): `string`
 
-*Defined in [functions.ts:96](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L96)*
+*Defined in [functions.ts:96](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L96)*
 
 This is a function with rest parameter.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **genericFunction**T(value: *`T`*): `T`
 
-*Defined in [functions.ts:140](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L140)*
+*Defined in [functions.ts:140](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L140)*
 
 This is a generic function.
 
@@ -160,7 +160,7 @@ ___
 
 ▸ **internalFunction**(): `void`
 
-*Defined in [functions.ts:13](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L13)*
+*Defined in [functions.ts:13](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L13)*
 
 This is an internal function.
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **multipleSignatures**(value: *`object`*): `string`
 
-*Defined in [functions.ts:106](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L106)*
+*Defined in [functions.ts:106](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L106)*
 
 This is the first signature of a function with multiple signatures.
 
@@ -187,7 +187,7 @@ This is the first signature of a function with multiple signatures.
 
 **Returns:** `string`
 
-*Defined in [functions.ts:114](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L114)*
+*Defined in [functions.ts:114](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L114)*
 
 This is the second signature of a function with multiple signatures.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **variableFunction**(paramZ: *`string`*, paramG: *`any`*, paramA: *[INameInterface](../interfaces/_classes_.inameinterface.md)*): `number`
 
-*Defined in [functions.ts:38](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L38)*
+*Defined in [functions.ts:38](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L38)*
 
 This is a function with multiple arguments and a return value.
 

--- a/test/fixtures/gitbook/modules/_functions_.modulefunction.md
+++ b/test/fixtures/gitbook/modules/_functions_.modulefunction.md
@@ -3,9 +3,10 @@
 This is the module extending the function moduleFunction().
 
 # Callable
+
 ▸ **moduleFunction**(arg: *`string`*): `string`
 
-*Defined in [functions.ts:150](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L150)*
+*Defined in [functions.ts:150](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L150)*
 
 This is a function that is extended by a module.
 
@@ -19,15 +20,6 @@ This is a function that is extended by a module.
 
 # Index
 
-### Variables
-
-* [functionVariable](_functions_.modulefunction.md#functionvariable)
-
-### Functions
-
-* [append](_functions_.modulefunction.md#append)
-* [prepend](_functions_.modulefunction.md#prepend)
-
 ---
 
 # Variables
@@ -38,7 +30,7 @@ This is a function that is extended by a module.
 
 **● functionVariable**: *`string`*
 
-*Defined in [functions.ts:160](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L160)*
+*Defined in [functions.ts:160](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L160)*
 
 This variable is appended to a function.
 
@@ -52,7 +44,7 @@ ___
 
 ▸ **append**(): `void`
 
-*Defined in [functions.ts:166](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L166)*
+*Defined in [functions.ts:166](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L166)*
 
 This function is appended to another function.
 
@@ -65,7 +57,7 @@ ___
 
 ▸ **prepend**(): `void`
 
-*Defined in [functions.ts:173](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L173)*
+*Defined in [functions.ts:173](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L173)*
 
 This function is appended to another function.
 

--- a/test/fixtures/gitbook/modules/_generics_.md
+++ b/test/fixtures/gitbook/modules/_generics_.md
@@ -11,19 +11,6 @@ Examples taken from the TypeDoc 'generics' examples directory ([https://github.c
 * [MySecondClass](../classes/_generics_.mysecondclass.md)
 * [MyThirdClass](../classes/_generics_.mythirdclass.md)
 
-### Interfaces
-
-* [A](../interfaces/_generics_.a.md)
-* [AB](../interfaces/_generics_.ab.md)
-* [ABNumber](../interfaces/_generics_.abnumber.md)
-* [ABString](../interfaces/_generics_.abstring.md)
-* [B](../interfaces/_generics_.b.md)
-
-### Functions
-
-* [getGenericArray](_generics_.md#getgenericarray)
-* [testFunction](_generics_.md#testfunction)
-
 ---
 
 # Functions
@@ -34,7 +21,7 @@ Examples taken from the TypeDoc 'generics' examples directory ([https://github.c
 
 ▸ **getGenericArray**(): `Array`<`string`>
 
-*Defined in [generics.ts:83](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L83)*
+*Defined in [generics.ts:83](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L83)*
 
 A function returning a generic array with type parameters.
 
@@ -48,7 +35,7 @@ ___
 
 ▸ **testFunction**T(value: *`T`*): `T`
 
-*Defined in [generics.ts:15](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L15)*
+*Defined in [generics.ts:15](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L15)*
 
 A generic function
 

--- a/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
@@ -35,7 +35,7 @@
 
 **ΤSearchFunc**: *`function`*
 
-*Defined in [interfaces.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
+*Defined in [interfaces.ts:62](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
 
 #### Type declaration
 ▸(source: *`string`*, subString: *`string`*): `boolean`
@@ -59,7 +59,7 @@ ___
 
 **● mySearch**: *[SearchFunc](_interfaces_.interfaces.md#searchfunc)*
 
-*Defined in [interfaces.ts:64](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L64)*
+*Defined in [interfaces.ts:64](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L64)*
 
 ___
 <a id="square-1"></a>
@@ -68,7 +68,7 @@ ___
 
 **● square**: *[Square](../interfaces/_interfaces_.interfaces.square.md)* =  {} as Square
 
-*Defined in [interfaces.ts:98](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L98)*
+*Defined in [interfaces.ts:98](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L98)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **createClock**(ctor: *[ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md)*, hour: *`number`*, minute: *`number`*): [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
 
-*Defined in [interfaces.ts:86](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L86)*
+*Defined in [interfaces.ts:86](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L86)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/modules/_variables_.md
+++ b/test/fixtures/gitbook/modules/_variables_.md
@@ -8,7 +8,7 @@
 
 **● amount**: *`number`* = 6
 
-*Defined in [variables.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L9)*
+*Defined in [variables.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L9)*
 
 This is a number type
 
@@ -19,7 +19,7 @@ ___
 
 **● color**: *`string`* = "blue"
 
-*Defined in [variables.ts:14](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L14)*
+*Defined in [variables.ts:14](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L14)*
 
 This is a string type
 
@@ -30,7 +30,7 @@ ___
 
 **● isDone**: *`boolean`* = false
 
-*Defined in [variables.ts:4](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L4)*
+*Defined in [variables.ts:4](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L4)*
 
 This is a boolean type
 
@@ -41,7 +41,7 @@ ___
 
 **● numbers**: *`number`[]* =  [1, 2, 3]
 
-*Defined in [variables.ts:19](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L19)*
+*Defined in [variables.ts:19](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L19)*
 
 This is an array type
 

--- a/test/fixtures/github/classes/_access_.privateclass.md
+++ b/test/fixtures/github/classes/_access_.privateclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md) > [PrivateClass](../classes/_access_.privateclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md) > [PrivateClass](../classes/_access_.privateclass.md)
 
-# Class: PrivateClass
+# PrivateClass
 
 A class that is documented as being private.
 
@@ -30,7 +30,7 @@ A class that is documented as being private.
 
 **● fakePrivateVariable**: *`string`*
 
-*Defined in [access.ts:41](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L41)*
+*Defined in [access.ts:41](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L41)*
 
 A variable that is made private via comment.
 
@@ -41,7 +41,7 @@ ___
 
 **● fakeProtectedVariable**: *`string`*
 
-*Defined in [access.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L47)*
+*Defined in [access.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L47)*
 
 A variable that is made protected via comment.
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **fakePrivateFunction**(): `void`
 
-*Defined in [access.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L53)*
+*Defined in [access.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L53)*
 
 A function that is made private via comment.
 
@@ -68,7 +68,7 @@ ___
 
 ▸ **fakeProtectedFunction**(): `void`
 
-*Defined in [access.ts:59](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L59)*
+*Defined in [access.ts:59](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L59)*
 
 A function that is made protected via comment.
 

--- a/test/fixtures/github/classes/_classes_.baseclass.md
+++ b/test/fixtures/github/classes/_classes_.baseclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [BaseClass](../classes/_classes_.baseclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [BaseClass](../classes/_classes_.baseclass.md)
 
-# Class: BaseClass
+# BaseClass
 
 This is a simple base class.
 
@@ -57,7 +57,7 @@ This is a simple example on how to use BaseClass.
 
 ⊕ **new BaseClass**(source: *[BaseClass](_classes_.baseclass.md)*): [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 **Parameters:**
 
@@ -67,7 +67,7 @@ This is a simple example on how to use BaseClass.
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:81](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
+*Defined in [classes.ts:81](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
 
 **Parameters:**
 
@@ -87,7 +87,7 @@ ___
 
 **● internalClass**: *[InternalClass](_classes_.internalclass.md)<`keyof BaseClass`>*
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 This is an instance member of an internal class.
 
@@ -98,7 +98,7 @@ ___
 
 **● kind**: *`number`*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -111,7 +111,7 @@ ___
 
 *Implementation of [INameInterface](../interfaces/_classes_.inameinterface.md).[name](../interfaces/_classes_.inameinterface.md#name)*
 
-*Defined in [classes.ts:60](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L60)*
+*Defined in [classes.ts:60](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L60)*
 
 This is a simple public member.
 
@@ -122,7 +122,7 @@ ___
 
 **● instance**: *[BaseClass](_classes_.baseclass.md)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -135,7 +135,7 @@ ___
 
 **● instances**: *[BaseClass](_classes_.baseclass.md)[]*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **abstractMethod**(): `void`
 
-*Defined in [classes.ts:95](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L95)*
+*Defined in [classes.ts:95](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L95)*
 
 **Returns:** `void`
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **arrowFunction**(param2: *`string`*, param1: *`number`*): `void`
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **checkName**(): `boolean`
 
-*Defined in [classes.ts:150](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L150)*
+*Defined in [classes.ts:150](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L150)*
 
 This is a private function.
 
@@ -193,7 +193,7 @@ ___
 
 *Implementation of [INameInterface](../interfaces/_classes_.inameinterface.md).[getName](../interfaces/_classes_.inameinterface.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -209,7 +209,7 @@ ___
 
 ▸ **setName**(name: *`string`*): `void`
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **caTest**(originalValues: *[BaseClass](_classes_.baseclass.md)*, newRecord: *`any`*, fieldNames: *`string`[]*, mandatoryFields: *`string`[]*): `string`
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -252,7 +252,7 @@ ___
 
 ▸ **getInstance**(): [BaseClass](_classes_.baseclass.md)
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **getName**(): `string`
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/github/classes/_classes_.genericclass.md
+++ b/test/fixtures/github/classes/_classes_.genericclass.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [GenericClass](../classes/_classes_.genericclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [GenericClass](../classes/_classes_.genericclass.md)
 
-# Class: GenericClass
+# GenericClass
 
 This is a generic class.
 
 ## Type parameters
+
 #### T :  [BaseClass](_classes_.baseclass.md)
 
 This a type parameter.
@@ -44,7 +45,7 @@ This a type parameter.
 
 ⊕ **new GenericClass**(p1: *`any`*, p2: *`T`*, p3: *`number`*, p4: *`number`*, p5: *`string`*): [GenericClass](_classes_.genericclass.md)
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -70,7 +71,7 @@ ___
 
 **● p2**: *`T`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -81,7 +82,7 @@ ___
 
 **● p3**: *`number`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -92,7 +93,7 @@ ___
 
 **● p4**: *`number`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public implicit any property
 
@@ -103,7 +104,7 @@ ___
 
 **● p5**: *`string`*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -114,7 +115,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -126,7 +127,7 @@ ___
 
 ▸ **getValue**(): `T`
 
-*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
+*Defined in [classes.ts:314](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** `T`
 
@@ -137,7 +138,7 @@ ___
 
 ▸ **setValue**(value: *`T`*): `void`
 
-*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
+*Defined in [classes.ts:310](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_classes_.internalclass.md
+++ b/test/fixtures/github/classes/_classes_.internalclass.md
@@ -1,20 +1,17 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [InternalClass](../classes/_classes_.internalclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [InternalClass](../classes/_classes_.internalclass.md)
 
-# Class: InternalClass
+# InternalClass
 
 This is an internal class, it is not exported.
 
 ## Type parameters
+
 #### TTT :  `keyof BaseClass`
 ## Hierarchy
 
 **InternalClass**
 
 ## Index
-
-### Constructors
-
-* [constructor](_classes_.internalclass.md#constructor)
 
 ---
 
@@ -26,7 +23,7 @@ This is an internal class, it is not exported.
 
 ⊕ **new InternalClass**(options: *`object`*): [InternalClass](_classes_.internalclass.md)
 
-*Defined in [classes.ts:187](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L187)*
+*Defined in [classes.ts:187](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L187)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_classes_.nongenericclass.md
+++ b/test/fixtures/github/classes/_classes_.nongenericclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [NonGenericClass](../classes/_classes_.nongenericclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [NonGenericClass](../classes/_classes_.nongenericclass.md)
 
-# Class: NonGenericClass
+# NonGenericClass
 
 This a non generic class derived from a [generic class](_classes_.genericclass.md).
 
@@ -40,7 +40,7 @@ This a non generic class derived from a [generic class](_classes_.genericclass.m
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[constructor](_classes_.genericclass.md#constructor)*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p2](_classes_.genericclass.md#p2)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p3](_classes_.genericclass.md#p3)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p5](_classes_.genericclass.md#p5)*
 
-*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
+*Defined in [classes.ts:304](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[value](_classes_.genericclass.md#value)*
 
-*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
+*Defined in [classes.ts:293](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[getValue](_classes_.genericclass.md#getvalue)*
 
-*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
+*Defined in [classes.ts:314](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -134,7 +134,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[setValue](_classes_.genericclass.md#setvalue)*
 
-*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
+*Defined in [classes.ts:310](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_classes_.subclassa.md
+++ b/test/fixtures/github/classes/_classes_.subclassa.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [SubClassA](../classes/_classes_.subclassa.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [SubClassA](../classes/_classes_.subclassa.md)
 
-# Class: SubClassA
+# SubClassA
 
 This is a class that extends another class.
 
@@ -62,7 +62,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:78](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
+*Defined in [classes.ts:78](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L78)*
 
 **Parameters:**
 
@@ -74,7 +74,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:81](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
+*Defined in [classes.ts:81](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L81)*
 
 **Parameters:**
 
@@ -96,7 +96,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[kind](_classes_.baseclass.md#kind)*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -111,7 +111,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[name](_classes_.baseclass.md#name)*
 
-*Defined in [classes.ts:200](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L200)*
+*Defined in [classes.ts:200](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L200)*
 
 ___
 <a id="instance"></a>
@@ -122,7 +122,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instance](_classes_.baseclass.md#instance)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -137,7 +137,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instances](_classes_.baseclass.md#instances)*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -149,14 +149,14 @@ ___
 
 getnameProperty(): `string`setnameProperty(value: *`string`*): `void`
 
-*Defined in [classes.ts:219](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
+*Defined in [classes.ts:219](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
 
 Returns the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
 **Returns:** `string`
 The return value.
 
-*Defined in [classes.ts:229](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L229)*
+*Defined in [classes.ts:229](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L229)*
 
 Sets the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -176,7 +176,7 @@ ___
 
 getreadOnlyNameProperty(): `string`
 
-*Defined in [classes.ts:238](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
+*Defined in [classes.ts:238](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
 
 Returns the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -190,7 +190,7 @@ ___
 
 setwriteOnlyNameProperty(value: *`string`*): `void`
 
-*Defined in [classes.ts:248](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
+*Defined in [classes.ts:248](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
 
 Sets the name. See [BaseClass.name](_classes_.baseclass.md#name).
 
@@ -215,7 +215,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[abstractMethod](_classes_.baseclass.md#abstractmethod)*
 
-*Defined in [classes.ts:252](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L252)*
+*Defined in [classes.ts:252](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L252)*
 
 **Returns:** `void`
 
@@ -228,7 +228,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[arrowFunction](_classes_.baseclass.md#arrowfunction)*
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -252,7 +252,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -270,7 +270,7 @@ ___
 
 *Implementation of [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md).[print](../interfaces/_classes_.iprintnameinterface.md#print)*
 
-*Defined in [classes.ts:205](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L205)*
+*Defined in [classes.ts:205](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L205)*
 
 This is a simple interface function.
 
@@ -291,7 +291,7 @@ ___
 
 *Implementation of [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md).[printName](../interfaces/_classes_.iprintnameinterface.md#printname)*
 
-*Defined in [classes.ts:210](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L210)*
+*Defined in [classes.ts:210](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L210)*
 
 This is a interface function of IPrintNameInterface
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[setName](_classes_.baseclass.md#setname)*
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -329,7 +329,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[caTest](_classes_.baseclass.md#catest)*
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getInstance](_classes_.baseclass.md#getinstance)*
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -371,7 +371,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname-1)*
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/github/classes/_classes_.subclassb.md
+++ b/test/fixtures/github/classes/_classes_.subclassb.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [SubClassB](../classes/_classes_.subclassb.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [SubClassB](../classes/_classes_.subclassb.md)
 
-# Class: SubClassB
+# SubClassB
 
 This is a class that extends another class.
 
@@ -53,7 +53,7 @@ The constructor of the original class should be overwritten.
 
 *Overrides [BaseClass](_classes_.baseclass.md).[constructor](_classes_.baseclass.md#constructor)*
 
-*Defined in [classes.ts:263](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
+*Defined in [classes.ts:263](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[kind](_classes_.baseclass.md#kind)*
 
-*Defined in [classes.ts:65](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
+*Defined in [classes.ts:65](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L65)*
 
 This is a simple protected member.
 
@@ -90,7 +90,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[name](_classes_.baseclass.md#name)*
 
-*Defined in [classes.ts:263](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
+*Defined in [classes.ts:263](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L263)*
 
 ___
 <a id="instance"></a>
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instance](_classes_.baseclass.md#instance)*
 
-*Defined in [classes.ts:72](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
+*Defined in [classes.ts:72](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L72)*
 
 This is a static member.
 
@@ -116,7 +116,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[instances](_classes_.baseclass.md#instances)*
 
-*Defined in [classes.ts:73](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
+*Defined in [classes.ts:73](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L73)*
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 *Overrides [BaseClass](_classes_.baseclass.md).[abstractMethod](_classes_.baseclass.md#abstractmethod)*
 
-*Defined in [classes.ts:269](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L269)*
+*Defined in [classes.ts:269](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L269)*
 
 **Returns:** `void`
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[arrowFunction](_classes_.baseclass.md#arrowfunction)*
 
-*Defined in [classes.ts:143](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
+*Defined in [classes.ts:143](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L143)*
 
 This is a simple fat arrow function.
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **doOtherThings**(value: * `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)*, secondValue?: *[SubClassA](_classes_.subclassa.md)*): `void`
 
-*Defined in [classes.ts:282](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
+*Defined in [classes.ts:282](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
 
 Description for doOtherThings.
 
@@ -183,7 +183,7 @@ ___
 
 ▸ **doSomething**(value: *[`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)]*): `void`
 
-*Defined in [classes.ts:273](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L273)*
+*Defined in [classes.ts:273](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L273)*
 
 **Parameters:**
 
@@ -204,7 +204,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname)*
 
-*Defined in [classes.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
+*Defined in [classes.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L105)*
 
 This is a simple member function.
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[setName](_classes_.baseclass.md#setname)*
 
-*Defined in [classes.ts:130](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
+*Defined in [classes.ts:130](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L130)*
 
 This is a simple member function.
 
@@ -245,7 +245,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[caTest](_classes_.baseclass.md#catest)*
 
-*Defined in [classes.ts:170](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
+*Defined in [classes.ts:170](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L170)*
 
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/42](https://github.com/sebastian-lenz/typedoc/issues/42)
 
@@ -269,7 +269,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getInstance](_classes_.baseclass.md#getinstance)*
 
-*Defined in [classes.ts:162](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
+*Defined in [classes.ts:162](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L162)*
 
 This is a static function.
 
@@ -287,7 +287,7 @@ ___
 
 *Inherited from [BaseClass](_classes_.baseclass.md).[getName](_classes_.baseclass.md#getname-1)*
 
-*Defined in [classes.ts:118](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
+*Defined in [classes.ts:118](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L118)*
 
 This is a simple static member function.
 

--- a/test/fixtures/github/classes/_default_export_.defaultexportedclass.md
+++ b/test/fixtures/github/classes/_default_export_.defaultexportedclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md) > [DefaultExportedClass](../classes/_default_export_.defaultexportedclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md) > [DefaultExportedClass](../classes/_default_export_.defaultexportedclass.md)
 
-# Class: DefaultExportedClass
+# DefaultExportedClass
 
 This class is exported via es6 export syntax.
 
@@ -36,7 +36,7 @@ export default class DefaultExportedClass {}
 
 ⊕ **new DefaultExportedClass**(): [DefaultExportedClass](_default_export_.defaultexportedclass.md)
 
-*Defined in [default-export.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
+*Defined in [default-export.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
 
 This is the constructor of the default exported class.
 
@@ -52,7 +52,7 @@ ___
 
 **● exportedProperty**: *`string`*
 
-*Defined in [default-export.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
+*Defined in [default-export.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L50)*
 
 Property of default exported class.
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **getExportedProperty**(): `string`
 
-*Defined in [default-export.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L62)*
+*Defined in [default-export.ts:62](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L62)*
 
 Method of default exported class.
 

--- a/test/fixtures/github/classes/_default_export_.notexportedclassname.md
+++ b/test/fixtures/github/classes/_default_export_.notexportedclassname.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md) > [NotExportedClassName](../classes/_default_export_.notexportedclassname.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md) > [NotExportedClassName](../classes/_default_export_.notexportedclassname.md)
 
-# Class: NotExportedClassName
+# NotExportedClassName
 
 This class is exported under a different name. The exported name is "ExportedClassName"
 
@@ -13,10 +13,6 @@ export {NotExportedClassName as ExportedClassName};
 **NotExportedClassName**
 
 ## Index
-
-### Constructors
-
-* [constructor](_default_export_.notexportedclassname.md#constructor)
 
 ### Properties
 
@@ -36,7 +32,7 @@ export {NotExportedClassName as ExportedClassName};
 
 ⊕ **new NotExportedClassName**(): [NotExportedClassName](_default_export_.notexportedclassname.md)
 
-*Defined in [default-export.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
+*Defined in [default-export.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
 
 This is the constructor of the NotExportedClassName class.
 
@@ -52,7 +48,7 @@ ___
 
 **● notExportedProperty**: *`string`*
 
-*Defined in [default-export.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
+*Defined in [default-export.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L21)*
 
 Property of NotExportedClassName class.
 
@@ -66,7 +62,7 @@ ___
 
 ▸ **getNotExportedProperty**(): `string`
 
-*Defined in [default-export.ts:33](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L33)*
+*Defined in [default-export.ts:33](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/default-export.ts#L33)*
 
 Method of NotExportedClassName class.
 

--- a/test/fixtures/github/classes/_flattened_.flattenedclass.md
+++ b/test/fixtures/github/classes/_flattened_.flattenedclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["flattened"](../modules/_flattened_.md) > [flattenedClass](../classes/_flattened_.flattenedclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["flattened"](../modules/_flattened_.md) > [flattenedClass](../classes/_flattened_.flattenedclass.md)
 
-# Class: flattenedClass
+# flattenedClass
 
 A class that contains members with flattened properties.
 
@@ -9,10 +9,6 @@ A class that contains members with flattened properties.
 **flattenedClass**
 
 ## Index
-
-### Constructors
-
-* [constructor](_flattened_.flattenedclass.md#constructor)
 
 ### Properties
 
@@ -31,7 +27,7 @@ A class that contains members with flattened properties.
 
 ⊕ **new flattenedClass**(options: *`object`*): [flattenedClass](_flattened_.flattenedclass.md)
 
-*Defined in [flattened.ts:64](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L64)*
+*Defined in [flattened.ts:64](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L64)*
 
 A constructor that accepts an option object defined inline.
 
@@ -53,7 +49,7 @@ ___
 
 **● callback**: *`function`*
 
-*Defined in [flattened.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L35)*
+*Defined in [flattened.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L35)*
 
 A member that holds a callback that requires a typed function signature.
 
@@ -76,7 +72,7 @@ ___
 
 **● indexed**: *`object`*
 
-*Defined in [flattened.ts:43](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L43)*
+*Defined in [flattened.ts:43](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L43)*
 
 A member that holds an index signature.
 
@@ -99,7 +95,7 @@ ___
 
 **● multipleCallSignatures**: *`function`*
 
-*Defined in [flattened.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L52)*
+*Defined in [flattened.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L52)*
 
 An object with multiple call signatures.
 *__see__*: [https://github.com/sebastian-lenz/typedoc/issues/27](https://github.com/sebastian-lenz/typedoc/issues/27)
@@ -130,7 +126,7 @@ ___
 
 **● options**: *`object`*
 
-*Defined in [flattened.ts:21](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L21)*
+*Defined in [flattened.ts:21](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L21)*
 
 A member that accepts an option object defined inline.
 

--- a/test/fixtures/github/classes/_generics_.myfirstclass.md
+++ b/test/fixtures/github/classes/_generics_.myfirstclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyFirstClass](../classes/_generics_.myfirstclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyFirstClass](../classes/_generics_.myfirstclass.md)
 
-# Class: MyFirstClass
+# MyFirstClass
 
 ## Hierarchy
 

--- a/test/fixtures/github/classes/_generics_.myfourthclass.md
+++ b/test/fixtures/github/classes/_generics_.myfourthclass.md
@@ -1,8 +1,9 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyFourthClass](../classes/_generics_.myfourthclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyFourthClass](../classes/_generics_.myfourthclass.md)
 
-# Class: MyFourthClass
+# MyFourthClass
 
 ## Type parameters
+
 #### K 
 #### V 
 ## Hierarchy

--- a/test/fixtures/github/classes/_generics_.mysecondclass.md
+++ b/test/fixtures/github/classes/_generics_.mysecondclass.md
@@ -1,8 +1,9 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MySecondClass](../classes/_generics_.mysecondclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MySecondClass](../classes/_generics_.mysecondclass.md)
 
-# Class: MySecondClass
+# MySecondClass
 
 ## Type parameters
+
 #### T 
 ## Hierarchy
 

--- a/test/fixtures/github/classes/_generics_.mythirdclass.md
+++ b/test/fixtures/github/classes/_generics_.mythirdclass.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyThirdClass](../classes/_generics_.mythirdclass.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [MyThirdClass](../classes/_generics_.mythirdclass.md)
 
-# Class: MyThirdClass
+# MyThirdClass
 
 ## Hierarchy
 
@@ -26,7 +26,7 @@
 
 ⊕ **new MyThirdClass**(arg: *[MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>>*): [MyThirdClass](_generics_.mythirdclass.md)
 
-*Defined in [generics.ts:93](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L93)*
+*Defined in [generics.ts:93](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L93)*
 
 **Parameters:**
 
@@ -46,7 +46,7 @@ ___
 
 **● arg**: *[MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>>*
 
-*Defined in [generics.ts:94](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L94)*
+*Defined in [generics.ts:94](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L94)*
 
 ___
 

--- a/test/fixtures/github/classes/_interfaces_.color.md
+++ b/test/fixtures/github/classes/_interfaces_.color.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [Color](../classes/_interfaces_.color.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [Color](../classes/_interfaces_.color.md)
 
-# Class: Color
+# Color
 
 ## Hierarchy
 
@@ -40,7 +40,7 @@
 
 ⊕ **new Color**(r: *`number`*, g: *`number`*, b: *`number`*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:24](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L24)*
+*Defined in [interfaces.ts:24](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L24)*
 
 **Parameters:**
 
@@ -62,7 +62,7 @@ ___
 
 **● b**: *`number`*
 
-*Defined in [interfaces.ts:27](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L27)*
+*Defined in [interfaces.ts:27](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L27)*
 
 ___
 <a id="g"></a>
@@ -71,7 +71,7 @@ ___
 
 **● g**: *`number`*
 
-*Defined in [interfaces.ts:26](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L26)*
+*Defined in [interfaces.ts:26](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L26)*
 
 ___
 <a id="r"></a>
@@ -80,7 +80,7 @@ ___
 
 **● r**: *`number`*
 
-*Defined in [interfaces.ts:25](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L25)*
+*Defined in [interfaces.ts:25](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L25)*
 
 ___
 <a id="background"></a>
@@ -89,7 +89,7 @@ ___
 
 **● background**: *[Color](_interfaces_.color.md)* =  Color.black
 
-*Defined in [interfaces.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L35)*
+*Defined in [interfaces.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L35)*
 
 ___
 <a id="black"></a>
@@ -98,7 +98,7 @@ ___
 
 **● black**: *[Color](_interfaces_.color.md)* =  new Color(0.0, 0.0, 0.0)
 
-*Defined in [interfaces.ts:34](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L34)*
+*Defined in [interfaces.ts:34](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L34)*
 
 ___
 <a id="defaultcolor"></a>
@@ -107,7 +107,7 @@ ___
 
 **● defaultColor**: *[Color](_interfaces_.color.md)* =  Color.black
 
-*Defined in [interfaces.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L36)*
+*Defined in [interfaces.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L36)*
 
 ___
 <a id="grey"></a>
@@ -116,7 +116,7 @@ ___
 
 **● grey**: *[Color](_interfaces_.color.md)* =  new Color(0.5, 0.5, 0.5)
 
-*Defined in [interfaces.ts:33](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L33)*
+*Defined in [interfaces.ts:33](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L33)*
 
 ___
 <a id="white"></a>
@@ -125,7 +125,7 @@ ___
 
 **● white**: *[Color](_interfaces_.color.md)* =  new Color(1.0, 1.0, 1.0)
 
-*Defined in [interfaces.ts:32](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L32)*
+*Defined in [interfaces.ts:32](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L32)*
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **plus**(v1: *[Color](_interfaces_.color.md)*, v2: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L30)*
+*Defined in [interfaces.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L30)*
 
 **Parameters:**
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **scale**(k: *`number`*, v: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:29](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L29)*
+*Defined in [interfaces.ts:29](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L29)*
 
 **Parameters:**
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **times**(v1: *[Color](_interfaces_.color.md)*, v2: *[Color](_interfaces_.color.md)*): [Color](_interfaces_.color.md)
 
-*Defined in [interfaces.ts:31](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L31)*
+*Defined in [interfaces.ts:31](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L31)*
 
 **Parameters:**
 
@@ -191,7 +191,7 @@ ___
 
 ▸ **toDrawingColor**(c: *[Color](_interfaces_.color.md)*): `object`
 
-*Defined in [interfaces.ts:37](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L37)*
+*Defined in [interfaces.ts:37](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L37)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_interfaces_.vector.md
+++ b/test/fixtures/github/classes/_interfaces_.vector.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [Vector](../classes/_interfaces_.vector.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [Vector](../classes/_interfaces_.vector.md)
 
-# Class: Vector
+# Vector
 
 ## Hierarchy
 
@@ -38,7 +38,7 @@
 
 ⊕ **new Vector**(x: *`number`*, y: *`number`*, z: *`number`*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:2](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L2)*
+*Defined in [interfaces.ts:2](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L2)*
 
 **Parameters:**
 
@@ -60,7 +60,7 @@ ___
 
 **● x**: *`number`*
 
-*Defined in [interfaces.ts:3](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L3)*
+*Defined in [interfaces.ts:3](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L3)*
 
 ___
 <a id="y"></a>
@@ -69,7 +69,7 @@ ___
 
 **● y**: *`number`*
 
-*Defined in [interfaces.ts:4](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L4)*
+*Defined in [interfaces.ts:4](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L4)*
 
 ___
 <a id="z"></a>
@@ -78,7 +78,7 @@ ___
 
 **● z**: *`number`*
 
-*Defined in [interfaces.ts:5](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L5)*
+*Defined in [interfaces.ts:5](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L5)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **cross**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:17](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L17)*
+*Defined in [interfaces.ts:17](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L17)*
 
 **Parameters:**
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **dot**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): `number`
 
-*Defined in [interfaces.ts:10](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L10)*
+*Defined in [interfaces.ts:10](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L10)*
 
 **Parameters:**
 
@@ -126,7 +126,7 @@ ___
 
 ▸ **mag**(v: *[Vector](_interfaces_.vector.md)*): `number`
 
-*Defined in [interfaces.ts:11](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L11)*
+*Defined in [interfaces.ts:11](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L11)*
 
 **Parameters:**
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **minus**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:8](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L8)*
+*Defined in [interfaces.ts:8](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L8)*
 
 **Parameters:**
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **norm**(v: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:12](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L12)*
+*Defined in [interfaces.ts:12](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L12)*
 
 **Parameters:**
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **plus**(v1: *[Vector](_interfaces_.vector.md)*, v2: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L9)*
+*Defined in [interfaces.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L9)*
 
 **Parameters:**
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **times**(k: *`number`*, v: *[Vector](_interfaces_.vector.md)*): [Vector](_interfaces_.vector.md)
 
-*Defined in [interfaces.ts:7](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L7)*
+*Defined in [interfaces.ts:7](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L7)*
 
 **Parameters:**
 

--- a/test/fixtures/github/enums/_enumerations_.directions.md
+++ b/test/fixtures/github/enums/_enumerations_.directions.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md) > [Directions](../enums/_enumerations_.directions.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md) > [Directions](../enums/_enumerations_.directions.md)
 
-# Enumeration: Directions
+# Directions
 
 This is a simple Enumeration.
 
@@ -25,7 +25,7 @@ This is a simple Enumeration.
 
 **Bottom**: 
 
-*Defined in [enumerations.ts:25](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L25)*
+*Defined in [enumerations.ts:25](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L25)*
 
 A simple enum member.
 
@@ -36,7 +36,7 @@ ___
 
 **Left**: 
 
-*Defined in [enumerations.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L30)*
+*Defined in [enumerations.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L30)*
 
 A simple enum member.
 
@@ -47,7 +47,7 @@ ___
 
 **Right**: 
 
-*Defined in [enumerations.ts:20](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L20)*
+*Defined in [enumerations.ts:20](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L20)*
 
 A simple enum member.
 
@@ -58,7 +58,7 @@ ___
 
 **Top**: 
 
-*Defined in [enumerations.ts:15](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L15)*
+*Defined in [enumerations.ts:15](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L15)*
 
 A simple enum member.
 
@@ -69,7 +69,7 @@ ___
 
 **TopLeft**:  =  Top | Left
 
-*Defined in [enumerations.ts:35](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L35)*
+*Defined in [enumerations.ts:35](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L35)*
 
 A composite enum member.
 
@@ -80,7 +80,7 @@ ___
 
 **TopRight**:  =  Top | Right
 
-*Defined in [enumerations.ts:40](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L40)*
+*Defined in [enumerations.ts:40](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L40)*
 
 A composite enum member.
 

--- a/test/fixtures/github/enums/_enumerations_.size.md
+++ b/test/fixtures/github/enums/_enumerations_.size.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md) > [Size](../enums/_enumerations_.size.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md) > [Size](../enums/_enumerations_.size.md)
 
-# Enumeration: Size
+# Size
 
 This comment is ignored, as the enumeration is already defined.
 
@@ -30,7 +30,7 @@ This comment is ignored, as the enumeration is already defined.
 
 **Large**: 
 
-*Defined in [enumerations.ts:57](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L57)*
+*Defined in [enumerations.ts:57](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L57)*
 
 A simple enum member.
 
@@ -41,7 +41,7 @@ ___
 
 **Medium**: 
 
-*Defined in [enumerations.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L52)*
+*Defined in [enumerations.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L52)*
 
 A simple enum member.
 
@@ -52,7 +52,7 @@ ___
 
 **Small**: 
 
-*Defined in [enumerations.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L47)*
+*Defined in [enumerations.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L47)*
 
 A simple enum member.
 
@@ -66,7 +66,7 @@ ___
 
 **● defaultSize**: *[Size](_enumerations_.size.md)* =  Size.Medium
 
-*Defined in [enumerations.ts:68](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L68)*
+*Defined in [enumerations.ts:68](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L68)*
 
 A variable that is attached to an enumeration.
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **isSmall**(value: *[Size](_enumerations_.size.md)*): `boolean`
 
-*Defined in [enumerations.ts:77](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L77)*
+*Defined in [enumerations.ts:77](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/enumerations.ts#L77)*
 
 A function that is attached to an enumeration.
 

--- a/test/fixtures/github/interfaces/_classes_.inameinterface.md
+++ b/test/fixtures/github/interfaces/_classes_.inameinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [INameInterface](../interfaces/_classes_.inameinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [INameInterface](../interfaces/_classes_.inameinterface.md)
 
-# Interface: INameInterface
+# INameInterface
 
 This is a simple interface.
 
@@ -36,7 +36,7 @@ This is a simple interface.
 
 **● name**: *`string`*
 
-*Defined in [classes.ts:16](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
+*Defined in [classes.ts:16](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
 
 This is a interface member of INameInterface.
 
@@ -52,7 +52,7 @@ ___
 
 ▸ **getName**(): `string`
 
-*Defined in [classes.ts:23](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
+*Defined in [classes.ts:23](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
 
 This is a interface function of INameInterface.
 

--- a/test/fixtures/github/interfaces/_classes_.iprintinterface.md
+++ b/test/fixtures/github/interfaces/_classes_.iprintinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [IPrintInterface](../interfaces/_classes_.iprintinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [IPrintInterface](../interfaces/_classes_.iprintinterface.md)
 
-# Interface: IPrintInterface
+# IPrintInterface
 
 This is a simple interface.
 
@@ -26,7 +26,7 @@ This is a simple interface.
 
 ▸ **print**(value: *`string`*): `void`
 
-*Defined in [classes.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
+*Defined in [classes.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
 
 This is a interface function of IPrintInterface
 

--- a/test/fixtures/github/interfaces/_classes_.iprintnameinterface.md
+++ b/test/fixtures/github/interfaces/_classes_.iprintnameinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md) > [IPrintNameInterface](../interfaces/_classes_.iprintnameinterface.md)
 
-# Interface: IPrintNameInterface
+# IPrintNameInterface
 
 This is a interface inheriting from two other interfaces.
 
@@ -40,7 +40,7 @@ This is a interface inheriting from two other interfaces.
 
 *Inherited from [INameInterface](_classes_.inameinterface.md).[name](_classes_.inameinterface.md#name)*
 
-*Defined in [classes.ts:16](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
+*Defined in [classes.ts:16](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L16)*
 
 This is a interface member of INameInterface.
 
@@ -58,7 +58,7 @@ ___
 
 *Inherited from [INameInterface](_classes_.inameinterface.md).[getName](_classes_.inameinterface.md#getname)*
 
-*Defined in [classes.ts:23](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
+*Defined in [classes.ts:23](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L23)*
 
 This is a interface function of INameInterface.
 
@@ -75,7 +75,7 @@ ___
 
 *Inherited from [IPrintInterface](_classes_.iprintinterface.md).[print](_classes_.iprintinterface.md#print)*
 
-*Defined in [classes.ts:36](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
+*Defined in [classes.ts:36](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L36)*
 
 This is a interface function of IPrintInterface
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **printName**(): `void`
 
-*Defined in [classes.ts:47](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L47)*
+*Defined in [classes.ts:47](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L47)*
 
 This is a interface function of IPrintNameInterface
 

--- a/test/fixtures/github/interfaces/_generics_.a.md
+++ b/test/fixtures/github/interfaces/_generics_.a.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [A](../interfaces/_generics_.a.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [A](../interfaces/_generics_.a.md)
 
-# Interface: A
+# A
 
 A generic interface.
 
 ## Type parameters
+
 #### T 
 
 The generic type parameter.
@@ -31,7 +32,7 @@ The generic type parameter.
 
 ▸ **getT**(): `T`
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 

--- a/test/fixtures/github/interfaces/_generics_.ab.md
+++ b/test/fixtures/github/interfaces/_generics_.ab.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [AB](../interfaces/_generics_.ab.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [AB](../interfaces/_generics_.ab.md)
 
-# Interface: AB
+# AB
 
 A generic interface extending two other generic interfaces and setting one of the type parameters.
 
 ## Type parameters
+
 #### T 
 
 The leftover generic type parameter.
@@ -41,7 +42,7 @@ The leftover generic type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -57,7 +58,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -73,7 +74,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/github/interfaces/_generics_.abnumber.md
+++ b/test/fixtures/github/interfaces/_generics_.abnumber.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [ABNumber](../interfaces/_generics_.abnumber.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [ABNumber](../interfaces/_generics_.abnumber.md)
 
-# Interface: ABNumber
+# ABNumber
 
 An interface extending a generic interface and setting its type parameter.
 
@@ -30,7 +30,7 @@ An interface extending a generic interface and setting its type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/github/interfaces/_generics_.abstring.md
+++ b/test/fixtures/github/interfaces/_generics_.abstring.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [ABString](../interfaces/_generics_.abstring.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [ABString](../interfaces/_generics_.abstring.md)
 
-# Interface: ABString
+# ABString
 
 An interface extending a generic interface and setting its type parameter.
 
@@ -30,7 +30,7 @@ An interface extending a generic interface and setting its type parameter.
 
 *Inherited from [B](_generics_.b.md).[getC](_generics_.b.md#getc)*
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [A](_generics_.a.md).[getT](_generics_.a.md#gett)*
 
-*Defined in [generics.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
+*Defined in [generics.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L30)*
 
 A generic member function.
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [B](_generics_.b.md).[setT](_generics_.b.md#sett)*
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/github/interfaces/_generics_.b.md
+++ b/test/fixtures/github/interfaces/_generics_.b.md
@@ -1,10 +1,11 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [B](../interfaces/_generics_.b.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md) > [B](../interfaces/_generics_.b.md)
 
-# Interface: B
+# B
 
 A generic interface with two type parameters.
 
 ## Type parameters
+
 #### T 
 
 The first generic type parameter.
@@ -36,7 +37,7 @@ The second generic type parameter.
 
 ▸ **getC**(): `C`
 
-*Defined in [generics.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
+*Defined in [generics.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L53)*
 
 A generic member function.
 
@@ -50,7 +51,7 @@ ___
 
 ▸ **setT**(value: *`T`*): `void`
 
-*Defined in [generics.ts:46](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
+*Defined in [generics.ts:46](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L46)*
 
 A generic member function.
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.clockconstructor.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.clockconstructor.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md)
 
-# Interface: ClockConstructor
+# ClockConstructor
 
 ## Hierarchy
 
@@ -22,7 +22,7 @@
 
 ⊕ **new ClockConstructor**(hour: *`number`*, minute: *`number`*): [ClockInterface](_interfaces_.interfaces.clockinterface.md)
 
-*Defined in [interfaces.ts:79](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L79)*
+*Defined in [interfaces.ts:79](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L79)*
 
 **Parameters:**
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.clockinterface.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.clockinterface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
 
-# Interface: ClockInterface
+# ClockInterface
 
 ## Hierarchy
 
@@ -27,7 +27,7 @@
 
 **● currentTime**: *`Date`*
 
-*Defined in [interfaces.ts:75](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L75)*
+*Defined in [interfaces.ts:75](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L75)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 ▸ **setTime**(d: *`Date`*): `any`
 
-*Defined in [interfaces.ts:76](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L76)*
+*Defined in [interfaces.ts:76](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L76)*
 
 **Parameters:**
 
@@ -56,7 +56,7 @@ ___
 
 ▸ **tick**(): `any`
 
-*Defined in [interfaces.ts:83](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L83)*
+*Defined in [interfaces.ts:83](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L83)*
 
 **Returns:** `any`
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.shape.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.shape.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Shape](../interfaces/_interfaces_.interfaces.shape.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Shape](../interfaces/_interfaces_.interfaces.shape.md)
 
-# Interface: Shape
+# Shape
 
 ## Hierarchy
 
@@ -24,7 +24,7 @@
 
 **● color**: *`string`*
 
-*Defined in [interfaces.ts:91](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
+*Defined in [interfaces.ts:91](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
 
 ___
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.square.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.square.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Square](../interfaces/_interfaces_.interfaces.square.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Square](../interfaces/_interfaces_.interfaces.square.md)
 
-# Interface: Square
+# Square
 
 ## Hierarchy
 
@@ -27,7 +27,7 @@
 
 *Inherited from [Shape](_interfaces_.interfaces.shape.md).[color](_interfaces_.interfaces.shape.md#color)*
 
-*Defined in [interfaces.ts:91](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
+*Defined in [interfaces.ts:91](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L91)*
 
 ___
 <a id="sidelength"></a>
@@ -36,7 +36,7 @@ ___
 
 **● sideLength**: *`number`*
 
-*Defined in [interfaces.ts:95](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L95)*
+*Defined in [interfaces.ts:95](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L95)*
 
 ___
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.squareconfig.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.squareconfig.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [SquareConfig](../interfaces/_interfaces_.interfaces.squareconfig.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [SquareConfig](../interfaces/_interfaces_.interfaces.squareconfig.md)
 
-# Interface: SquareConfig
+# SquareConfig
 
 ## Hierarchy
 
@@ -23,7 +23,7 @@
 
 **● color**: *`string`*
 
-*Defined in [interfaces.ts:57](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L57)*
+*Defined in [interfaces.ts:57](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L57)*
 
 ___
 <a id="width"></a>
@@ -32,7 +32,7 @@ ___
 
 **● width**: *`number`*
 
-*Defined in [interfaces.ts:58](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L58)*
+*Defined in [interfaces.ts:58](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L58)*
 
 ___
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.stringarray.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.stringarray.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [StringArray](../interfaces/_interfaces_.interfaces.stringarray.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [StringArray](../interfaces/_interfaces_.interfaces.stringarray.md)
 
-# Interface: StringArray
+# StringArray
 
 ## Hierarchy
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.surface.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.surface.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Surface](../interfaces/_interfaces_.interfaces.surface.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md) > [Surface](../interfaces/_interfaces_.interfaces.surface.md)
 
-# Interface: Surface
+# Surface
 
 ## Hierarchy
 
@@ -25,7 +25,7 @@
 
 **● diffuse**: *`function`*
 
-*Defined in [interfaces.ts:50](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L50)*
+*Defined in [interfaces.ts:50](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L50)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): [Color](../classes/_interfaces_.color.md)
@@ -45,7 +45,7 @@ ___
 
 **● reflect**: *`function`*
 
-*Defined in [interfaces.ts:52](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L52)*
+*Defined in [interfaces.ts:52](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L52)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): `number`
@@ -65,7 +65,7 @@ ___
 
 **● roughness**: *`number`*
 
-*Defined in [interfaces.ts:53](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L53)*
+*Defined in [interfaces.ts:53](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L53)*
 
 ___
 <a id="specular"></a>
@@ -74,7 +74,7 @@ ___
 
 **● specular**: *`function`*
 
-*Defined in [interfaces.ts:51](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L51)*
+*Defined in [interfaces.ts:51](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L51)*
 
 #### Type declaration
 ▸(pos: *[Vector](../classes/_interfaces_.vector.md)*): [Color](../classes/_interfaces_.color.md)

--- a/test/fixtures/github/modules/_access_.md
+++ b/test/fixtures/github/modules/_access_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md)
 
-# External module: "access"
+# "access"
 
 Examples taken from the TypeDoc 'access' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/access.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/access.ts))
 
@@ -34,7 +34,7 @@ Examples taken from the TypeDoc 'access' examples directory ([https://github.com
 
 **● fakePrivateVariable**: *`string`* = "test"
 
-*Defined in [access.ts:12](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L12)*
+*Defined in [access.ts:12](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L12)*
 
 A variable that is made private via comment.
 
@@ -45,7 +45,7 @@ ___
 
 **● fakeProtectedVariable**: *`string`* = "test"
 
-*Defined in [access.ts:18](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L18)*
+*Defined in [access.ts:18](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L18)*
 
 A variable that is made protected via comment.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **fakePrivateFunction**(): `void`
 
-*Defined in [access.ts:24](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L24)*
+*Defined in [access.ts:24](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L24)*
 
 A function that is made private via comment.
 
@@ -72,7 +72,7 @@ ___
 
 ▸ **fakeProtectedFunction**(): `void`
 
-*Defined in [access.ts:30](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L30)*
+*Defined in [access.ts:30](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L30)*
 
 A function that is made protected via comment.
 

--- a/test/fixtures/github/modules/_access_.privatemodule.md
+++ b/test/fixtures/github/modules/_access_.privatemodule.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md) > [PrivateModule](../modules/_access_.privatemodule.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["access"](../modules/_access_.md) > [PrivateModule](../modules/_access_.privatemodule.md)
 
-# Module: PrivateModule
+# PrivateModule
 
 A module that is documented as being private.
 
@@ -20,7 +20,7 @@ A module that is documented as being private.
 
 ▸ **functionInsidePrivateModule**(): `void`
 
-*Defined in [access.ts:67](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/access.ts#L67)*
+*Defined in [access.ts:67](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/access.ts#L67)*
 
 **Returns:** `void`
 

--- a/test/fixtures/github/modules/_classes_.md
+++ b/test/fixtures/github/modules/_classes_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["classes"](../modules/_classes_.md)
 
-# External module: "classes"
+# "classes"
 
 Examples taken from the TypeDoc 'classes' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/classes.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/classes.ts))
 
@@ -10,7 +10,6 @@ Examples taken from the TypeDoc 'classes' examples directory ([https://github.co
 
 * [BaseClass](../classes/_classes_.baseclass.md)
 * [GenericClass](../classes/_classes_.genericclass.md)
-* [InternalClass](../classes/_classes_.internalclass.md)
 * [NonGenericClass](../classes/_classes_.nongenericclass.md)
 * [SubClassA](../classes/_classes_.subclassa.md)
 * [SubClassB](../classes/_classes_.subclassb.md)

--- a/test/fixtures/github/modules/_default_export_.md
+++ b/test/fixtures/github/modules/_default_export_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["default-export"](../modules/_default_export_.md)
 
-# External module: "default-export"
+# "default-export"
 
 Examples taken from the TypeDoc 'default-export' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/default-export.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/default-export.ts))
 
@@ -9,7 +9,6 @@ Examples taken from the TypeDoc 'default-export' examples directory ([https://gi
 ### Classes
 
 * [DefaultExportedClass](../classes/_default_export_.defaultexportedclass.md)
-* [NotExportedClassName](../classes/_default_export_.notexportedclassname.md)
 
 ---
 

--- a/test/fixtures/github/modules/_doc_comments_.md
+++ b/test/fixtures/github/modules/_doc_comments_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["doc-comments"](../modules/_doc_comments_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["doc-comments"](../modules/_doc_comments_.md)
 
-# External module: "doc-comments"
+# "doc-comments"
 
 ## Index
 
@@ -19,7 +19,7 @@
 
 **● commentsWithTags**: *`boolean`* = false
 
-*Defined in [doc-comments.ts:27](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L27)*
+*Defined in [doc-comments.ts:27](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L27)*
 
 *__name__*: AbstractMetadataModule
 
@@ -44,7 +44,7 @@ ___
 
 **● generalComments**: *`boolean`* = false
 
-*Defined in [doc-comments.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L9)*
+*Defined in [doc-comments.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/doc-comments.ts#L9)*
 
 Additionally you can link to other classes, members or functions using double square brackets.
 

--- a/test/fixtures/github/modules/_enumerations_.md
+++ b/test/fixtures/github/modules/_enumerations_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["enumerations"](../modules/_enumerations_.md)
 
-# External module: "enumerations"
+# "enumerations"
 
 Examples taken from the TypeDoc 'enumerations' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/enumerations.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/enumerations.ts))
 

--- a/test/fixtures/github/modules/_flattened_.md
+++ b/test/fixtures/github/modules/_flattened_.md
@@ -1,20 +1,10 @@
-[typedoc-plugin-markdown](../README.md) > ["flattened"](../modules/_flattened_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["flattened"](../modules/_flattened_.md)
 
-# External module: "flattened"
+# "flattened"
 
 Examples taken from the TypeDoc 'flattened' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/flattened.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/flattened.ts))
 
 ## Index
-
-### Classes
-
-* [flattenedClass](../classes/_flattened_.flattenedclass.md)
-
-### Functions
-
-* [flattenedCallback](_flattened_.md#flattenedcallback)
-* [flattenedIndexSignature](_flattened_.md#flattenedindexsignature)
-* [flattenedParameter](_flattened_.md#flattenedparameter)
 
 ---
 
@@ -26,7 +16,7 @@ Examples taken from the TypeDoc 'flattened' examples directory ([https://github.
 
 ▸ **flattenedCallback**(callback: *`function`*): `void`
 
-*Defined in [flattened.ts:93](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L93)*
+*Defined in [flattened.ts:93](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L93)*
 
 A function that has a parameter that requires a typed function callback.
 
@@ -45,7 +35,7 @@ ___
 
 ▸ **flattenedIndexSignature**(indexed: *`object`*): `void`
 
-*Defined in [flattened.ts:122](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L122)*
+*Defined in [flattened.ts:122](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L122)*
 
 A function that accepts an index signature parameter.
 
@@ -64,7 +54,7 @@ ___
 
 ▸ **flattenedParameter**(options: *`object`*): `void`
 
-*Defined in [flattened.ts:105](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L105)*
+*Defined in [flattened.ts:105](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/flattened.ts#L105)*
 
 A function that accepts an option object defined inline.
 

--- a/test/fixtures/github/modules/_functions_.md
+++ b/test/fixtures/github/modules/_functions_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["functions"](../modules/_functions_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["functions"](../modules/_functions_.md)
 
-# External module: "functions"
+# "functions"
 
 ## Index
 
@@ -16,11 +16,8 @@
 * [functionWithDefaults](_functions_.md#functionwithdefaults)
 * [functionWithDocLink](_functions_.md#functionwithdoclink)
 * [functionWithOptionalValue](_functions_.md#functionwithoptionalvalue)
-* [functionWithRest](_functions_.md#functionwithrest)
 * [genericFunction](_functions_.md#genericfunction)
-* [internalFunction](_functions_.md#internalfunction)
 * [multipleSignatures](_functions_.md#multiplesignatures)
-* [variableFunction](_functions_.md#variablefunction)
 
 ---
 
@@ -32,7 +29,7 @@
 
 ▸ **createSomething**(): `object`
 
-*Defined in [functions.ts:183](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L183)*
+*Defined in [functions.ts:183](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L183)*
 
 A function that returns an object. Also no type information is given, the object should be correctly reflected.
 
@@ -45,7 +42,7 @@ ___
 
 ▸ **exportedFunction**(): `void`
 
-*Defined in [functions.ts:19](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L19)*
+*Defined in [functions.ts:19](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L19)*
 
 This is a simple exported function.
 
@@ -58,7 +55,7 @@ ___
 
 ▸ **functionWithArguments**(paramZ: *`string`*, paramG: *`any`*, paramA: *[INameInterface](../interfaces/_classes_.inameinterface.md)*): `number`
 
-*Defined in [functions.ts:59](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L59)*
+*Defined in [functions.ts:59](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L59)*
 
 This is a function with multiple arguments and a return value.
 
@@ -79,7 +76,7 @@ ___
 
 ▸ **functionWithDefaults**(valueA?: *`string`*, valueB?: *`number`*, valueC?: *`number`*, valueD?: *`boolean`*, valueE?: *`boolean`*): `string`
 
-*Defined in [functions.ts:79](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L79)*
+*Defined in [functions.ts:79](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L79)*
 
 This is a function with a parameter that has a default value.
 
@@ -103,7 +100,7 @@ ___
 
 ▸ **functionWithDocLink**(): `void`
 
-*Defined in [functions.ts:199](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L199)*
+*Defined in [functions.ts:199](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L199)*
 
 See [`INameInterface`](../interfaces/_classes_.inameinterface.md) and [INameInterface's name property](../interfaces/_classes_.inameinterface.md#name). Also, check out [Google](http://www.google.com) and [GitHub](https://github.com).
 
@@ -118,7 +115,7 @@ ___
 
 ▸ **functionWithOptionalValue**(requiredParam: *`string`*, optionalParam?: *`string`*): `void`
 
-*Defined in [functions.ts:70](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L70)*
+*Defined in [functions.ts:70](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L70)*
 
 This is a function with a parameter that is optional.
 
@@ -138,7 +135,7 @@ ___
 
 ▸ **functionWithRest**(...rest: *`string`[]*): `string`
 
-*Defined in [functions.ts:96](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L96)*
+*Defined in [functions.ts:96](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L96)*
 
 This is a function with rest parameter.
 
@@ -158,7 +155,7 @@ ___
 
 ▸ **genericFunction**T(value: *`T`*): `T`
 
-*Defined in [functions.ts:140](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L140)*
+*Defined in [functions.ts:140](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L140)*
 
 This is a generic function.
 
@@ -184,7 +181,7 @@ ___
 
 ▸ **internalFunction**(): `void`
 
-*Defined in [functions.ts:13](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L13)*
+*Defined in [functions.ts:13](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L13)*
 
 This is an internal function.
 
@@ -199,7 +196,7 @@ ___
 
 ▸ **multipleSignatures**(value: *`object`*): `string`
 
-*Defined in [functions.ts:106](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L106)*
+*Defined in [functions.ts:106](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L106)*
 
 This is the first signature of a function with multiple signatures.
 
@@ -211,7 +208,7 @@ This is the first signature of a function with multiple signatures.
 
 **Returns:** `string`
 
-*Defined in [functions.ts:114](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L114)*
+*Defined in [functions.ts:114](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L114)*
 
 This is the second signature of a function with multiple signatures.
 
@@ -230,7 +227,7 @@ ___
 
 ▸ **variableFunction**(paramZ: *`string`*, paramG: *`any`*, paramA: *[INameInterface](../interfaces/_classes_.inameinterface.md)*): `number`
 
-*Defined in [functions.ts:38](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L38)*
+*Defined in [functions.ts:38](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L38)*
 
 This is a function with multiple arguments and a return value.
 

--- a/test/fixtures/github/modules/_functions_.modulefunction.md
+++ b/test/fixtures/github/modules/_functions_.modulefunction.md
@@ -1,13 +1,14 @@
-[typedoc-plugin-markdown](../README.md) > ["functions"](../modules/_functions_.md) > [moduleFunction](../modules/_functions_.modulefunction.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["functions"](../modules/_functions_.md) > [moduleFunction](../modules/_functions_.modulefunction.md)
 
-# Module: moduleFunction
+# moduleFunction
 
 This is the module extending the function moduleFunction().
 
 ## Callable
+
 ▸ **moduleFunction**(arg: *`string`*): `string`
 
-*Defined in [functions.ts:150](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L150)*
+*Defined in [functions.ts:150](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L150)*
 
 This is a function that is extended by a module.
 
@@ -21,15 +22,6 @@ This is a function that is extended by a module.
 
 ## Index
 
-### Variables
-
-* [functionVariable](_functions_.modulefunction.md#functionvariable)
-
-### Functions
-
-* [append](_functions_.modulefunction.md#append)
-* [prepend](_functions_.modulefunction.md#prepend)
-
 ---
 
 ## Variables
@@ -40,7 +32,7 @@ This is a function that is extended by a module.
 
 **● functionVariable**: *`string`*
 
-*Defined in [functions.ts:160](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L160)*
+*Defined in [functions.ts:160](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L160)*
 
 This variable is appended to a function.
 
@@ -54,7 +46,7 @@ ___
 
 ▸ **append**(): `void`
 
-*Defined in [functions.ts:166](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L166)*
+*Defined in [functions.ts:166](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L166)*
 
 This function is appended to another function.
 
@@ -67,7 +59,7 @@ ___
 
 ▸ **prepend**(): `void`
 
-*Defined in [functions.ts:173](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L173)*
+*Defined in [functions.ts:173](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L173)*
 
 This function is appended to another function.
 

--- a/test/fixtures/github/modules/_generics_.md
+++ b/test/fixtures/github/modules/_generics_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["generics"](../modules/_generics_.md)
 
-# External module: "generics"
+# "generics"
 
 Examples taken from the TypeDoc 'generics' examples directory ([https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/generics.ts](https://github.com/TypeStrong/typedoc/blob/master/examples/basic/src/generics.ts))
 
@@ -13,19 +13,6 @@ Examples taken from the TypeDoc 'generics' examples directory ([https://github.c
 * [MySecondClass](../classes/_generics_.mysecondclass.md)
 * [MyThirdClass](../classes/_generics_.mythirdclass.md)
 
-### Interfaces
-
-* [A](../interfaces/_generics_.a.md)
-* [AB](../interfaces/_generics_.ab.md)
-* [ABNumber](../interfaces/_generics_.abnumber.md)
-* [ABString](../interfaces/_generics_.abstring.md)
-* [B](../interfaces/_generics_.b.md)
-
-### Functions
-
-* [getGenericArray](_generics_.md#getgenericarray)
-* [testFunction](_generics_.md#testfunction)
-
 ---
 
 ## Functions
@@ -36,7 +23,7 @@ Examples taken from the TypeDoc 'generics' examples directory ([https://github.c
 
 ▸ **getGenericArray**(): `Array`<`string`>
 
-*Defined in [generics.ts:83](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L83)*
+*Defined in [generics.ts:83](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L83)*
 
 A function returning a generic array with type parameters.
 
@@ -50,7 +37,7 @@ ___
 
 ▸ **testFunction**T(value: *`T`*): `T`
 
-*Defined in [generics.ts:15](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L15)*
+*Defined in [generics.ts:15](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/generics.ts#L15)*
 
 A generic function
 

--- a/test/fixtures/github/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/github/modules/_interfaces_.interfaces.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md) > [interfaces](../modules/_interfaces_.interfaces.md)
 
-# Module: interfaces
+# interfaces
 
 ## Index
 
@@ -37,7 +37,7 @@
 
 **ΤSearchFunc**: *`function`*
 
-*Defined in [interfaces.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
+*Defined in [interfaces.ts:62](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
 
 #### Type declaration
 ▸(source: *`string`*, subString: *`string`*): `boolean`
@@ -61,7 +61,7 @@ ___
 
 **● mySearch**: *[SearchFunc](_interfaces_.interfaces.md#searchfunc)*
 
-*Defined in [interfaces.ts:64](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L64)*
+*Defined in [interfaces.ts:64](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L64)*
 
 ___
 <a id="square-1"></a>
@@ -70,7 +70,7 @@ ___
 
 **● square**: *[Square](../interfaces/_interfaces_.interfaces.square.md)* =  {} as Square
 
-*Defined in [interfaces.ts:98](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L98)*
+*Defined in [interfaces.ts:98](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L98)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **createClock**(ctor: *[ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md)*, hour: *`number`*, minute: *`number`*): [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
 
-*Defined in [interfaces.ts:86](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L86)*
+*Defined in [interfaces.ts:86](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L86)*
 
 **Parameters:**
 

--- a/test/fixtures/github/modules/_interfaces_.md
+++ b/test/fixtures/github/modules/_interfaces_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["interfaces"](../modules/_interfaces_.md)
 
-# External module: "interfaces"
+# "interfaces"
 
 ## Index
 

--- a/test/fixtures/github/modules/_variables_.md
+++ b/test/fixtures/github/modules/_variables_.md
@@ -1,6 +1,6 @@
-[typedoc-plugin-markdown](../README.md) > ["variables"](../modules/_variables_.md)
+[@bigcommerce/typedoc-plugin-markdown](../README.md) > ["variables"](../modules/_variables_.md)
 
-# External module: "variables"
+# "variables"
 
 ## Index
 
@@ -21,7 +21,7 @@
 
 **● amount**: *`number`* = 6
 
-*Defined in [variables.ts:9](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L9)*
+*Defined in [variables.ts:9](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L9)*
 
 This is a number type
 
@@ -32,7 +32,7 @@ ___
 
 **● color**: *`string`* = "blue"
 
-*Defined in [variables.ts:14](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L14)*
+*Defined in [variables.ts:14](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L14)*
 
 This is a string type
 
@@ -43,7 +43,7 @@ ___
 
 **● isDone**: *`boolean`* = false
 
-*Defined in [variables.ts:4](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L4)*
+*Defined in [variables.ts:4](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L4)*
 
 This is a boolean type
 
@@ -54,7 +54,7 @@ ___
 
 **● numbers**: *`number`[]* =  [1, 2, 3]
 
-*Defined in [variables.ts:19](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L19)*
+*Defined in [variables.ts:19](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/variables.ts#L19)*
 
 This is an array type
 


### PR DESCRIPTION
## What?
* Modify the markdown template to suit our needs.

## Why?
* Only list out exported members, unless they are methods or properties of a class or interface.
* Remove information that's less important to declutter the output.

## Testing / Proof
* Run `typedoc --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown`

ping @bigcommerce/checkout 
