### PR TITLE
CHECKOUT-3777: Format tag based on its value

### DIFF
--- a/src/theme/helpers/formatTagName.ts
+++ b/src/theme/helpers/formatTagName.ts
@@ -1,0 +1,14 @@
+/**
+ * Format a tag name based on its value. If the tag is considered to be
+ * important, the function will wrap it with an emphasis markup. If the tag can
+ * be ignored, the function will return an empty line instead.
+ *
+ * @param tagName The tag name to format
+ */
+export function formatTagName(tagName: string): string {
+  if (tagName === 'remarks') {
+    return '\n';
+  }
+
+  return `*__${tagName}__*: `;
+}

--- a/src/theme/partials/comment.hbs
+++ b/src/theme/partials/comment.hbs
@@ -10,7 +10,7 @@
 {{/if}}
 {{~#if tags}}
 {{#each tags}}
-*__{{tagName}}__*: {{#getMarkdownFromHtml}}{{#markdown}}{{{text}}}{{/markdown}}{{/getMarkdownFromHtml}}
+{{formatTagName tagName}}{{#getMarkdownFromHtml}}{{#markdown}}{{{text}}}{{/markdown}}{{/getMarkdownFromHtml}}
 
 {{/each}}
 {{~/if}}

--- a/test/fixtures/bitbucket/README.md
+++ b/test/fixtures/bitbucket/README.md
@@ -53,6 +53,7 @@
 * [functionWithDefaults](#markdown-header-functionwithdefaults)
 * [functionWithDocLink](#markdown-header-functionwithdoclink)
 * [functionWithOptionalValue](#markdown-header-functionwithoptionalvalue)
+* [functionWithTags](#markdown-header-functionwithtags)
 * [genericFunction](#markdown-header-genericfunction)
 * [multipleSignatures](#markdown-header-multiplesignatures)
 
@@ -352,6 +353,22 @@ This is a function with rest parameter.
 
 **Returns:** `string`
 The combined string.
+
+___
+
+###  functionWithTags
+
+▸ **functionWithTags**(): `void`
+
+*Defined in [functions.ts:211](https://bitbucket.org/owner/repository_name/src/master/functions.ts?fileviewer&amp;#x3D;file-view-default#functions.ts-211)*
+
+A simple function that does something.
+
+This is a paragraph containing more information about the usage of this function.
+
+*__alpha__*: This is a sentence describing the stability of the API.
+
+**Returns:** `void`
 
 ___
 

--- a/test/fixtures/gitbook/modules/_functions_.md
+++ b/test/fixtures/gitbook/modules/_functions_.md
@@ -128,6 +128,23 @@ This is a function with rest parameter.
 The combined string.
 
 ___
+<a id="functionwithtags"></a>
+
+##  functionWithTags
+
+▸ **functionWithTags**(): `void`
+
+*Defined in [functions.ts:211](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L211)*
+
+A simple function that does something.
+
+This is a paragraph containing more information about the usage of this function.
+
+*__alpha__*: This is a sentence describing the stability of the API.
+
+**Returns:** `void`
+
+___
 <a id="genericfunction"></a>
 
 ##  genericFunction

--- a/test/fixtures/github/modules/_functions_.md
+++ b/test/fixtures/github/modules/_functions_.md
@@ -16,6 +16,7 @@
 * [functionWithDefaults](_functions_.md#functionwithdefaults)
 * [functionWithDocLink](_functions_.md#functionwithdoclink)
 * [functionWithOptionalValue](_functions_.md#functionwithoptionalvalue)
+* [functionWithTags](_functions_.md#functionwithtags)
 * [genericFunction](_functions_.md#genericfunction)
 * [multipleSignatures](_functions_.md#multiplesignatures)
 
@@ -147,6 +148,23 @@ This is a function with rest parameter.
 
 **Returns:** `string`
 The combined string.
+
+___
+<a id="functionwithtags"></a>
+
+###  functionWithTags
+
+▸ **functionWithTags**(): `void`
+
+*Defined in [functions.ts:211](https://github.com/bigcommerce/typedoc-plugin-markdown/blob/master/test/src/functions.ts#L211)*
+
+A simple function that does something.
+
+This is a paragraph containing more information about the usage of this function.
+
+*__alpha__*: This is a sentence describing the stability of the API.
+
+**Returns:** `void`
 
 ___
 <a id="genericfunction"></a>

--- a/test/src/functions.ts
+++ b/test/src/functions.ts
@@ -198,4 +198,16 @@ export function createSomething() {
  */
 export function functionWithDocLink(): void { }
 
+
+/**
+ * A simple function that does something.
+ *
+ * @remarks
+ * This is a paragraph containing more information about the usage of this function.
+ *
+ * @alpha
+ * This is a sentence describing the stability of the API.
+ */
+export function functionWithTags(): void { }
+
  /* tslint:enable */


### PR DESCRIPTION
## What?
* Format tags, i.e.: `@remarks`, `@alpha` based on its value.

## Why?
* We don't want to output `@remarks` in the docs because it's just redundant. It's meant to indicate that a docblock has a description. But in the context of generating the docs, they are meaningless and therefore can be removed from the docs.

## Testing / Proof
* Unit

ping @bigcommerce/frontend @bigcommerce/checkout 
